### PR TITLE
Add home base: claim a region, gather resources, watch visiting NPCs

### DIFF
--- a/components/PhaserGame.tsx
+++ b/components/PhaserGame.tsx
@@ -14,6 +14,7 @@ export default function PhaserGame() {
       const Phaser = (await import("phaser")).default;
       const { BootScene } = await import("@/lib/render/scenes/BootScene");
       const { WorldScene } = await import("@/lib/render/scenes/WorldScene");
+      const { HomeScene } = await import("@/lib/render/scenes/HomeScene");
 
       if (cancelled || !containerRef.current) return;
 
@@ -28,7 +29,7 @@ export default function PhaserGame() {
           width: containerRef.current.clientWidth,
           height: containerRef.current.clientHeight,
         },
-        scene: [BootScene, WorldScene],
+        scene: [BootScene, WorldScene, HomeScene],
         input: {
           activePointers: 3,
         },

--- a/components/hud/HUD.tsx
+++ b/components/hud/HUD.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import Link from "next/link";
-import { House, Pause, Play, FastForward } from "@phosphor-icons/react/dist/ssr";
+import {
+  House,
+  Pause,
+  Play,
+  FastForward,
+  MapTrifold,
+  Lightning,
+} from "@phosphor-icons/react/dist/ssr";
 import { useGameStore } from "@/lib/state/game-store";
+import { RESOURCES, type ResourceKind } from "@/content/home-resources";
 
 const SPEEDS = [1, 2, 4] as const;
 
@@ -12,46 +20,137 @@ export default function HUD() {
   const ticks = useGameStore((s) => s.world?.ticks ?? 0);
   const togglePause = useGameStore((s) => s.togglePause);
   const setSpeed = useGameStore((s) => s.setSpeed);
+  const view = useGameStore((s) => s.view);
+  const setView = useGameStore((s) => s.setView);
+  const homePending = useGameStore((s) => s.homePending);
+  const hasHome = useGameStore((s) => Boolean(s.world?.home));
+  const player = useGameStore((s) => s.world?.player ?? null);
+  const inventory = useGameStore((s) => s.world?.inventory ?? {});
 
   return (
-    <header className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-start justify-between p-3">
-      <Link
-        href="/"
-        aria-label="Back to menu"
-        className="tactile pointer-events-auto inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
-      >
-        <House size={18} weight="duotone" className="text-[var(--color-fg)]" />
-      </Link>
-
-      <div className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] py-1 pl-3.5 pr-1.5 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]">
-        <span className="select-none font-mono text-xs tabular-nums text-[var(--color-fg-muted)]">
-          {ticks.toString().padStart(4, "0")}
-        </span>
-
-        <span className="mx-1 h-4 w-px bg-[var(--color-border)]" aria-hidden />
-
-        <button
-          aria-label={paused ? "Resume" : "Pause"}
-          aria-pressed={paused}
-          onClick={togglePause}
-          className="tactile inline-flex h-8 w-8 items-center justify-center rounded-full text-[var(--color-fg)] hover:bg-[var(--color-surface-warm)]"
+    <>
+      <header className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-start justify-between p-3">
+        <Link
+          href="/"
+          aria-label="Back to menu"
+          className="tactile pointer-events-auto inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
         >
-          {paused ? <Play size={16} weight="fill" /> : <Pause size={16} weight="fill" />}
-        </button>
+          <House size={18} weight="duotone" className="text-[var(--color-fg)]" />
+        </Link>
 
-        <button
-          aria-label={`Speed ${speed}x, tap to cycle`}
-          onClick={() => {
-            const idx = SPEEDS.indexOf(speed as (typeof SPEEDS)[number]);
-            const next = SPEEDS[(idx + 1) % SPEEDS.length] ?? 1;
-            setSpeed(next);
-          }}
-          className="tactile inline-flex h-8 items-center gap-1 rounded-full px-2.5 text-[var(--color-fg)] hover:bg-[var(--color-surface-warm)]"
-        >
-          <FastForward size={14} weight="fill" />
-          <span className="font-mono text-[11px] tabular-nums">{speed}x</span>
-        </button>
+        <div className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] py-1 pl-3.5 pr-1.5 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]">
+          <span className="select-none font-mono text-xs tabular-nums text-[var(--color-fg-muted)]">
+            {ticks.toString().padStart(4, "0")}
+          </span>
+
+          <span className="mx-1 h-4 w-px bg-[var(--color-border)]" aria-hidden />
+
+          <button
+            aria-label={paused ? "Resume" : "Pause"}
+            aria-pressed={paused}
+            onClick={togglePause}
+            className="tactile inline-flex h-8 w-8 items-center justify-center rounded-full text-[var(--color-fg)] hover:bg-[var(--color-surface-warm)]"
+          >
+            {paused ? <Play size={16} weight="fill" /> : <Pause size={16} weight="fill" />}
+          </button>
+
+          <button
+            aria-label={`Speed ${speed}x, tap to cycle`}
+            onClick={() => {
+              const idx = SPEEDS.indexOf(speed as (typeof SPEEDS)[number]);
+              const next = SPEEDS[(idx + 1) % SPEEDS.length] ?? 1;
+              setSpeed(next);
+            }}
+            className="tactile inline-flex h-8 items-center gap-1 rounded-full px-2.5 text-[var(--color-fg)] hover:bg-[var(--color-surface-warm)]"
+          >
+            <FastForward size={14} weight="fill" />
+            <span className="font-mono text-[11px] tabular-nums">{speed}x</span>
+          </button>
+
+          {hasHome && (
+            <>
+              <span className="mx-1 h-4 w-px bg-[var(--color-border)]" aria-hidden />
+              <button
+                aria-label={view === "home" ? "Switch to world map" : "Enter home base"}
+                onClick={() => setView(view === "home" ? "world" : "home")}
+                className="tactile inline-flex h-8 w-8 items-center justify-center rounded-full text-[var(--color-fg)] hover:bg-[var(--color-surface-warm)]"
+              >
+                {view === "home" ? (
+                  <MapTrifold size={16} weight="duotone" />
+                ) : (
+                  <House size={16} weight="duotone" />
+                )}
+              </button>
+            </>
+          )}
+        </div>
+      </header>
+
+      {homePending && view === "world" && (
+        <div className="pointer-events-none absolute inset-x-0 top-16 z-10 flex justify-center px-3">
+          <div className="rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-1.5 font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)] shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]">
+            Tap a region to claim your home base
+          </div>
+        </div>
+      )}
+
+      {view === "home" && player && (
+        <div className="pointer-events-none absolute inset-x-2 top-16 z-10 flex flex-wrap items-center justify-end gap-2">
+          <EnergyStrip energy={player.energy} max={player.energyMax} />
+          <InventoryStrip inventory={inventory} />
+        </div>
+      )}
+    </>
+  );
+}
+
+function EnergyStrip({ energy, max }: { energy: number; max: number }) {
+  return (
+    <div className="pointer-events-auto inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]">
+      <Lightning size={14} weight="fill" className="text-[var(--color-accent)]" />
+      <div className="flex items-center gap-[3px]">
+        {Array.from({ length: max }).map((_, i) => (
+          <span
+            key={i}
+            aria-hidden
+            className="h-2.5 w-2 rounded-[2px]"
+            style={{
+              background:
+                i < energy ? "var(--color-accent)" : "var(--color-surface-warm)",
+              border:
+                i < energy
+                  ? "1px solid var(--color-accent)"
+                  : "1px solid var(--color-border)",
+            }}
+          />
+        ))}
       </div>
-    </header>
+      <span className="ml-1 font-mono text-[10px] tabular-nums text-[var(--color-fg-muted)]">
+        {energy}/{max}
+      </span>
+    </div>
+  );
+}
+
+function InventoryStrip({ inventory }: { inventory: Partial<Record<ResourceKind, number>> }) {
+  const entries = (Object.entries(inventory) as Array<[ResourceKind, number]>).filter(
+    ([, n]) => n > 0,
+  );
+  if (entries.length === 0) return null;
+  return (
+    <div className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]">
+      {entries.map(([kind, count]) => (
+        <span key={kind} className="inline-flex items-center gap-1">
+          <span
+            aria-hidden
+            className="h-2.5 w-2.5 rounded-sm border border-[var(--color-border-strong)]"
+            style={{ background: RESOURCES[kind].swatch }}
+          />
+          <span className="font-mono text-[10px] tabular-nums text-[var(--color-fg)]">
+            {count}
+          </span>
+        </span>
+      ))}
+    </div>
   );
 }

--- a/components/panels/RegionPanel.tsx
+++ b/components/panels/RegionPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { X } from "@phosphor-icons/react/dist/ssr";
+import { House, X } from "@phosphor-icons/react/dist/ssr";
 import { useGameStore } from "@/lib/state/game-store";
 import { biomeAt } from "@/lib/sim/biome";
 import { BIOMES } from "@/content/biomes";
@@ -11,6 +11,8 @@ export default function RegionPanel() {
   const world = useGameStore((s) => s.world);
   const select = useGameStore((s) => s.selectRegion);
   const selectNpc = useGameStore((s) => s.selectNpc);
+  const homePending = useGameStore((s) => s.homePending);
+  const claimHome = useGameStore((s) => s.claimHome);
 
   if (!region || !world) return null;
 
@@ -20,6 +22,7 @@ export default function RegionPanel() {
   const incoming = world.npcs.filter(
     (n) => n.intent && n.intent.rx === region.rx && n.intent.ry === region.ry,
   );
+  const canClaim = homePending && meta.passable;
 
   return (
     <aside
@@ -56,6 +59,16 @@ export default function RegionPanel() {
         <p className="border-t border-[var(--color-border)] pt-4 text-sm leading-relaxed text-[var(--color-fg)] max-w-[60ch]">
           {meta.blurb}
         </p>
+
+        {canClaim && (
+          <button
+            onClick={() => claimHome(region.rx, region.ry)}
+            className="tactile mt-4 inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-[var(--color-accent)] px-4 py-3 text-sm font-medium text-[var(--color-bg)] shadow-[0_8px_24px_-12px_rgba(217,104,70,0.5)]"
+          >
+            <House size={16} weight="fill" />
+            Claim as home base
+          </button>
+        )}
 
         <dl className="mt-4 grid grid-cols-[auto_1fr] items-start gap-x-5 gap-y-3">
           <dt className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">

--- a/content/home-resources.ts
+++ b/content/home-resources.ts
@@ -1,0 +1,36 @@
+import type { Biome } from "@/lib/sim/biome";
+
+export type ResourceKind =
+  | "wood"
+  | "berry"
+  | "herb"
+  | "grain"
+  | "stone"
+  | "ore"
+  | "shell"
+  | "reed";
+
+export type ResourceMeta = {
+  label: string;
+  swatch: string;
+};
+
+export const RESOURCES: Record<ResourceKind, ResourceMeta> = {
+  wood: { label: "Wood", swatch: "#8a6a4a" },
+  berry: { label: "Berry", swatch: "#b85b6e" },
+  herb: { label: "Herb", swatch: "#7aa05c" },
+  grain: { label: "Grain", swatch: "#d8b66a" },
+  stone: { label: "Stone", swatch: "#9c9588" },
+  ore: { label: "Ore", swatch: "#6f7a8e" },
+  shell: { label: "Shell", swatch: "#e8c8b0" },
+  reed: { label: "Reed", swatch: "#a8b878" },
+};
+
+// Water is intentionally excluded -- it's not claimable as a home base.
+export const BIOME_RESOURCES: Record<Biome, ResourceKind[]> = {
+  grass: ["grain", "herb"],
+  forest: ["wood", "berry"],
+  sand: ["shell", "reed"],
+  stone: ["stone", "ore"],
+  water: [],
+};

--- a/lib/render/scenes/BootScene.ts
+++ b/lib/render/scenes/BootScene.ts
@@ -1,4 +1,5 @@
 import Phaser from "phaser";
+import { useGameStore } from "@/lib/state/game-store";
 
 export class BootScene extends Phaser.Scene {
   constructor() {
@@ -6,6 +7,7 @@ export class BootScene extends Phaser.Scene {
   }
 
   create() {
-    this.scene.start("World");
+    const view = useGameStore.getState().view;
+    this.scene.start(view === "home" ? "Home" : "World");
   }
 }

--- a/lib/render/scenes/HomeScene.ts
+++ b/lib/render/scenes/HomeScene.ts
@@ -1,0 +1,542 @@
+import Phaser from "phaser";
+import { useGameStore } from "@/lib/state/game-store";
+import { HOME_GRID } from "@/lib/sim/home";
+import { BIOMES } from "@/content/biomes";
+import { RESOURCES } from "@/content/home-resources";
+import type { Npc } from "@/lib/sim/npc";
+
+const CELL = 56;
+const PADDING = 4;
+const RADIUS = 8;
+const INNER = CELL - PADDING * 2;
+
+const NPC_SIZE = 22;
+const NPC_RADIUS = 5;
+const RESOURCE_SIZE = 22;
+const RESOURCE_RADIUS = 5;
+const PLAYER_SIZE = 28;
+const PLAYER_RADIUS = 6;
+
+const VISIT_BUCKET_TICKS = 24;
+
+const COLORS = {
+  bg: 0xf6f1e8,
+  player: 0xd96846,
+  selection: 0xd96846,
+  routeDot: 0xd96846,
+  npcStroke: 0xfbf6ed,
+  obstacleShadow: 0x2c2820,
+};
+
+type ResourceView = {
+  graphic: Phaser.GameObjects.Graphics;
+  hit: Phaser.GameObjects.Rectangle;
+  px: number;
+  py: number;
+};
+
+type VisitorView = {
+  body: Phaser.GameObjects.Graphics;
+  hit: Phaser.GameObjects.Rectangle;
+  targetCx: number;
+  targetCy: number;
+  cx: number;
+  cy: number;
+};
+
+export class HomeScene extends Phaser.Scene {
+  private tileLayer!: Phaser.GameObjects.Graphics;
+  private routeLayer!: Phaser.GameObjects.Graphics;
+  private playerLayer!: Phaser.GameObjects.Container;
+  private selectionRing!: Phaser.GameObjects.Graphics;
+  private playerGraphic!: Phaser.GameObjects.Graphics;
+  private playerShadow!: Phaser.GameObjects.Graphics;
+  private resourceViews = new Map<string, ResourceView>();
+  private visitorViews = new Map<string, VisitorView>();
+
+  private playerPx = 0;
+  private playerPy = 0;
+  private playerTransitionStart = 0;
+  private prevPlayerPx = 0;
+  private prevPlayerPy = 0;
+
+  private dragStart: { x: number; y: number } | null = null;
+  private pinchInitial: { dist: number; zoom: number } | null = null;
+  private pointerDownAt = 0;
+  private pointerDownPos = { x: 0, y: 0 };
+  private tappedVisitorId: string | null = null;
+
+  private accumulator = 0;
+  private readonly tickStepMs = 250;
+
+  constructor() {
+    super("Home");
+  }
+
+  create() {
+    this.cameras.main.setBackgroundColor(COLORS.bg);
+    this.tileLayer = this.add.graphics();
+    this.routeLayer = this.add.graphics();
+    this.selectionRing = this.add.graphics();
+    this.selectionRing.setVisible(false);
+    this.playerLayer = this.add.container(0, 0);
+
+    this.playerShadow = this.add.graphics();
+    this.playerGraphic = this.add.graphics();
+    this.playerLayer.add([this.playerShadow, this.playerGraphic]);
+
+    const home = useGameStore.getState().world?.home;
+    const player = useGameStore.getState().world?.player;
+    if (player) {
+      this.playerPx = player.px;
+      this.playerPy = player.py;
+      this.prevPlayerPx = player.px;
+      this.prevPlayerPy = player.py;
+    }
+    if (home) this.drawTiles();
+
+    const worldPx = HOME_GRID * CELL;
+    this.cameras.main.setBounds(-200, -200, worldPx + 400, worldPx + 400);
+    this.cameras.main.centerOn(worldPx / 2, worldPx / 2);
+    this.cameras.main.setZoom(1);
+
+    this.input.addPointer(2);
+    this.input.on("pointerdown", this.onPointerDown, this);
+    this.input.on("pointermove", this.onPointerMove, this);
+    this.input.on("pointerup", this.onPointerUp, this);
+    this.input.on("wheel", this.onWheel, this);
+
+    this.scale.on("resize", this.handleResize, this);
+  }
+
+  shutdown() {
+    this.scale.off("resize", this.handleResize, this);
+    for (const view of this.resourceViews.values()) {
+      view.graphic.destroy();
+      view.hit.destroy();
+    }
+    this.resourceViews.clear();
+    for (const view of this.visitorViews.values()) {
+      view.body.destroy();
+      view.hit.destroy();
+    }
+    this.visitorViews.clear();
+  }
+
+  update(_time: number, delta: number) {
+    const store = useGameStore.getState();
+
+    if (store.view !== "home") {
+      this.scene.start("World");
+      return;
+    }
+
+    if (!store.paused) {
+      this.accumulator += delta * store.speed;
+      while (this.accumulator >= this.tickStepMs) {
+        this.accumulator -= this.tickStepMs;
+        store.tick();
+      }
+    }
+
+    this.renderHome();
+  }
+
+  private drawTiles() {
+    this.tileLayer.clear();
+    const home = useGameStore.getState().world?.home;
+    if (!home) return;
+    const meta = BIOMES[home.biome];
+    const baseColor = hexToInt(meta.swatch);
+    const altColor = mixToward(baseColor, 0xffffff, 0.08);
+    const obstacleColor = mixToward(baseColor, 0x000000, 0.32);
+
+    for (let y = 0; y < HOME_GRID; y++) {
+      for (let x = 0; x < HOME_GRID; x++) {
+        const isObstacle = home.obstacles[y * HOME_GRID + x];
+        const color = isObstacle ? obstacleColor : (x + y) % 2 === 0 ? baseColor : altColor;
+        const px = x * CELL + PADDING;
+        const py = y * CELL + PADDING;
+        this.tileLayer.fillStyle(color, 1);
+        this.tileLayer.fillRoundedRect(px, py, INNER, INNER, RADIUS);
+        if (isObstacle) {
+          this.tileLayer.fillStyle(COLORS.obstacleShadow, 0.12);
+          this.tileLayer.fillRoundedRect(px + 4, py + 4, INNER - 8, INNER - 8, RADIUS - 2);
+        }
+      }
+    }
+  }
+
+  private renderHome() {
+    const world = useGameStore.getState().world;
+    if (!world || !world.home || !world.player) return;
+    const { home, player } = world;
+    const now = this.time.now;
+
+    if (player.px !== this.playerPx || player.py !== this.playerPy) {
+      this.prevPlayerPx = this.playerPx;
+      this.prevPlayerPy = this.playerPy;
+      this.playerPx = player.px;
+      this.playerPy = player.py;
+      this.playerTransitionStart = now;
+    }
+
+    const stepMs = Math.max(1, player.stats.speed) * this.tickStepMs;
+    const t =
+      this.playerTransitionStart === 0
+        ? 1
+        : Math.min(1, (now - this.playerTransitionStart) / stepMs);
+    const eased = easeOutCubic(t);
+
+    const fromX = this.prevPlayerPx * CELL + CELL / 2;
+    const fromY = this.prevPlayerPy * CELL + CELL / 2;
+    const toX = this.playerPx * CELL + CELL / 2;
+    const toY = this.playerPy * CELL + CELL / 2;
+    const cx = fromX + (toX - fromX) * eased;
+    const cy = fromY + (toY - fromY) * eased;
+
+    this.playerShadow.clear();
+    this.playerShadow.fillStyle(COLORS.obstacleShadow, 0.18);
+    this.playerShadow.fillRoundedRect(
+      cx - PLAYER_SIZE / 2,
+      cy - PLAYER_SIZE / 2 + 2,
+      PLAYER_SIZE,
+      PLAYER_SIZE,
+      PLAYER_RADIUS,
+    );
+
+    this.playerGraphic.clear();
+    this.playerGraphic.fillStyle(COLORS.player, 1);
+    this.playerGraphic.fillRoundedRect(
+      cx - PLAYER_SIZE / 2,
+      cy - PLAYER_SIZE / 2,
+      PLAYER_SIZE,
+      PLAYER_SIZE,
+      PLAYER_RADIUS,
+    );
+    this.playerGraphic.lineStyle(2, COLORS.npcStroke, 1);
+    this.playerGraphic.strokeRoundedRect(
+      cx - PLAYER_SIZE / 2,
+      cy - PLAYER_SIZE / 2,
+      PLAYER_SIZE,
+      PLAYER_SIZE,
+      PLAYER_RADIUS,
+    );
+
+    if (t >= 1 && this.playerTransitionStart !== 0) this.playerTransitionStart = 0;
+
+    this.routeLayer.clear();
+    if (player.route && player.route.length > 0) {
+      const points: Array<{ x: number; y: number }> = [{ x: cx, y: cy }];
+      for (const p of player.route) {
+        points.push({ x: p.px * CELL + CELL / 2, y: p.py * CELL + CELL / 2 });
+      }
+      const pulse = 0.5 + 0.5 * Math.sin(now * 0.005);
+      this.routeLayer.lineStyle(2, COLORS.routeDot, 0.35 + 0.2 * pulse);
+      for (let i = 0; i < points.length - 1; i++) {
+        const a = points[i]!;
+        const b = points[i + 1]!;
+        const mid = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+        this.routeLayer.beginPath();
+        this.routeLayer.moveTo(a.x, a.y);
+        this.routeLayer.lineTo(mid.x, mid.y);
+        this.routeLayer.strokePath();
+      }
+      const last = points[points.length - 1]!;
+      this.routeLayer.fillStyle(COLORS.routeDot, 0.35 + 0.2 * pulse);
+      this.routeLayer.fillCircle(last.x, last.y, 4);
+    }
+
+    const seenResources = new Set<string>();
+    for (const r of home.resources) {
+      seenResources.add(r.id);
+      let view = this.resourceViews.get(r.id);
+      const rcx = r.px * CELL + CELL / 2;
+      const rcy = r.py * CELL + CELL / 2;
+      if (!view) {
+        const graphic = this.add.graphics();
+        const hit = this.add.rectangle(rcx, rcy, CELL - PADDING * 2, CELL - PADDING * 2, 0xffffff, 0);
+        hit.setInteractive({ useHandCursor: true });
+        hit.on(
+          "pointerdown",
+          (_p: Phaser.Input.Pointer, _x: number, _y: number, e: Phaser.Types.Input.EventData) => {
+            e.stopPropagation();
+            useGameStore.getState().walkPlayerTo(r.px, r.py);
+          },
+        );
+        view = { graphic, hit, px: r.px, py: r.py };
+        this.resourceViews.set(r.id, view);
+      }
+      const meta = RESOURCES[r.kind];
+      const color = hexToInt(meta.swatch);
+      const available = r.respawnAt === null;
+      view.graphic.clear();
+      view.graphic.fillStyle(COLORS.obstacleShadow, available ? 0.18 : 0.08);
+      view.graphic.fillRoundedRect(
+        rcx - RESOURCE_SIZE / 2,
+        rcy - RESOURCE_SIZE / 2 + 2,
+        RESOURCE_SIZE,
+        RESOURCE_SIZE,
+        RESOURCE_RADIUS,
+      );
+      view.graphic.fillStyle(color, available ? 1 : 0.25);
+      view.graphic.fillRoundedRect(
+        rcx - RESOURCE_SIZE / 2,
+        rcy - RESOURCE_SIZE / 2,
+        RESOURCE_SIZE,
+        RESOURCE_SIZE,
+        RESOURCE_RADIUS,
+      );
+      view.graphic.lineStyle(1.5, COLORS.npcStroke, available ? 1 : 0.4);
+      view.graphic.strokeRoundedRect(
+        rcx - RESOURCE_SIZE / 2,
+        rcy - RESOURCE_SIZE / 2,
+        RESOURCE_SIZE,
+        RESOURCE_SIZE,
+        RESOURCE_RADIUS,
+      );
+    }
+    for (const [id, view] of this.resourceViews) {
+      if (!seenResources.has(id)) {
+        view.graphic.destroy();
+        view.hit.destroy();
+        this.resourceViews.delete(id);
+      }
+    }
+
+    this.renderVisitors(world.npcs, home);
+    this.renderSelection();
+  }
+
+  private renderVisitors(npcs: Npc[], home: { rx: number; ry: number }) {
+    const world = useGameStore.getState().world;
+    if (!world) return;
+    const visitors = npcs.filter((n) => n.rx === home.rx && n.ry === home.ry);
+    const seen = new Set<string>();
+    const bucket = Math.floor(world.ticks / VISIT_BUCKET_TICKS);
+
+    for (const npc of visitors) {
+      seen.add(npc.id);
+      const slot = visitorSlot(npc.id, bucket, world.home);
+      const targetCx = slot.px * CELL + CELL / 2;
+      const targetCy = slot.py * CELL + CELL / 2;
+
+      let view = this.visitorViews.get(npc.id);
+      if (!view) {
+        const body = this.add.graphics();
+        const hit = this.add.rectangle(
+          targetCx,
+          targetCy,
+          NPC_SIZE + 16,
+          NPC_SIZE + 16,
+          0xffffff,
+          0,
+        );
+        hit.setInteractive({ useHandCursor: true });
+        hit.on(
+          "pointerdown",
+          (_p: Phaser.Input.Pointer, _x: number, _y: number, e: Phaser.Types.Input.EventData) => {
+            e.stopPropagation();
+            this.tappedVisitorId = npc.id;
+            useGameStore.getState().selectNpc(npc.id);
+          },
+        );
+        view = { body, hit, targetCx, targetCy, cx: targetCx, cy: targetCy };
+        this.visitorViews.set(npc.id, view);
+      }
+
+      if (view.targetCx !== targetCx || view.targetCy !== targetCy) {
+        view.targetCx = targetCx;
+        view.targetCy = targetCy;
+      }
+
+      const lerp = 0.08;
+      view.cx += (view.targetCx - view.cx) * lerp;
+      view.cy += (view.targetCy - view.cy) * lerp;
+
+      view.body.clear();
+      view.body.fillStyle(COLORS.obstacleShadow, 0.16);
+      view.body.fillRoundedRect(
+        view.cx - NPC_SIZE / 2,
+        view.cy - NPC_SIZE / 2 + 2,
+        NPC_SIZE,
+        NPC_SIZE,
+        NPC_RADIUS,
+      );
+      view.body.fillStyle(npc.factionColor, 1);
+      view.body.fillRoundedRect(
+        view.cx - NPC_SIZE / 2,
+        view.cy - NPC_SIZE / 2,
+        NPC_SIZE,
+        NPC_SIZE,
+        NPC_RADIUS,
+      );
+      view.body.lineStyle(2, COLORS.npcStroke, 1);
+      view.body.strokeRoundedRect(
+        view.cx - NPC_SIZE / 2,
+        view.cy - NPC_SIZE / 2,
+        NPC_SIZE,
+        NPC_SIZE,
+        NPC_RADIUS,
+      );
+      view.hit.x = view.cx;
+      view.hit.y = view.cy;
+    }
+
+    for (const [id, view] of this.visitorViews) {
+      if (!seen.has(id)) {
+        view.body.destroy();
+        view.hit.destroy();
+        this.visitorViews.delete(id);
+      }
+    }
+  }
+
+  private renderSelection() {
+    const { selectedNpcId } = useGameStore.getState();
+    this.selectionRing.clear();
+    if (selectedNpcId) {
+      const v = this.visitorViews.get(selectedNpcId);
+      if (v) {
+        const half = NPC_SIZE / 2 + 5;
+        this.selectionRing.lineStyle(2.5, COLORS.selection, 1);
+        this.selectionRing.strokeRoundedRect(
+          v.cx - half,
+          v.cy - half,
+          half * 2,
+          half * 2,
+          NPC_RADIUS + 2,
+        );
+        this.selectionRing.setVisible(true);
+        return;
+      }
+    }
+    this.selectionRing.setVisible(false);
+  }
+
+  private onPointerDown(pointer: Phaser.Input.Pointer) {
+    if (this.input.pointer1.isDown && this.input.pointer2.isDown) {
+      const dist = Phaser.Math.Distance.Between(
+        this.input.pointer1.x,
+        this.input.pointer1.y,
+        this.input.pointer2.x,
+        this.input.pointer2.y,
+      );
+      this.pinchInitial = { dist, zoom: this.cameras.main.zoom };
+      this.dragStart = null;
+      return;
+    }
+    this.dragStart = { x: pointer.x, y: pointer.y };
+    this.pointerDownAt = this.time.now;
+    this.pointerDownPos = { x: pointer.x, y: pointer.y };
+  }
+
+  private onPointerMove(pointer: Phaser.Input.Pointer) {
+    if (this.input.pointer1.isDown && this.input.pointer2.isDown && this.pinchInitial) {
+      const dist = Phaser.Math.Distance.Between(
+        this.input.pointer1.x,
+        this.input.pointer1.y,
+        this.input.pointer2.x,
+        this.input.pointer2.y,
+      );
+      const factor = dist / this.pinchInitial.dist;
+      const zoom = Phaser.Math.Clamp(this.pinchInitial.zoom * factor, 0.5, 2.5);
+      this.cameras.main.setZoom(zoom);
+      return;
+    }
+    if (this.dragStart && pointer.isDown) {
+      const dx = pointer.x - this.dragStart.x;
+      const dy = pointer.y - this.dragStart.y;
+      this.cameras.main.scrollX -= dx / this.cameras.main.zoom;
+      this.cameras.main.scrollY -= dy / this.cameras.main.zoom;
+      this.dragStart = { x: pointer.x, y: pointer.y };
+    }
+  }
+
+  private onPointerUp(pointer: Phaser.Input.Pointer) {
+    const wasVisitorTap = this.tappedVisitorId !== null;
+    this.tappedVisitorId = null;
+    const dt = this.time.now - this.pointerDownAt;
+    const moved = Phaser.Math.Distance.Between(
+      this.pointerDownPos.x,
+      this.pointerDownPos.y,
+      pointer.x,
+      pointer.y,
+    );
+
+    if (!wasVisitorTap && dt < 250 && moved < 8) {
+      const world = this.cameras.main.getWorldPoint(pointer.x, pointer.y);
+      const tx = Math.floor(world.x / CELL);
+      const ty = Math.floor(world.y / CELL);
+      if (tx >= 0 && tx < HOME_GRID && ty >= 0 && ty < HOME_GRID) {
+        useGameStore.getState().walkPlayerTo(tx, ty);
+      } else {
+        useGameStore.getState().selectNpc(null);
+      }
+    }
+
+    this.dragStart = null;
+    this.pinchInitial = null;
+  }
+
+  private onWheel(_p: Phaser.Input.Pointer, _o: unknown, _dx: number, dy: number) {
+    const zoom = Phaser.Math.Clamp(this.cameras.main.zoom - dy * 0.001, 0.5, 2.5);
+    this.cameras.main.setZoom(zoom);
+  }
+
+  private handleResize = (gameSize: Phaser.Structs.Size) => {
+    this.cameras.main.setSize(gameSize.width, gameSize.height);
+  };
+}
+
+function easeOutCubic(t: number): number {
+  const u = 1 - t;
+  return 1 - u * u * u;
+}
+
+function hexToInt(hex: string): number {
+  return parseInt(hex.replace("#", ""), 16);
+}
+
+function mixToward(color: number, target: number, t: number): number {
+  const r1 = (color >> 16) & 0xff;
+  const g1 = (color >> 8) & 0xff;
+  const b1 = color & 0xff;
+  const r2 = (target >> 16) & 0xff;
+  const g2 = (target >> 8) & 0xff;
+  const b2 = target & 0xff;
+  const r = Math.round(r1 + (r2 - r1) * t);
+  const g = Math.round(g1 + (g2 - g1) * t);
+  const b = Math.round(b1 + (b2 - b1) * t);
+  return (r << 16) | (g << 8) | b;
+}
+
+// Visiting NPCs land on a deterministic free tile derived from id + tick bucket.
+// Avoids the player's tile, obstacles and resource tiles where possible.
+function visitorSlot(
+  id: string,
+  bucket: number,
+  home: { obstacles: boolean[]; resources: { px: number; py: number }[] } | null | undefined,
+): { px: number; py: number } {
+  const seed = hashString(`${id}:${bucket}`);
+  const cells = HOME_GRID * HOME_GRID;
+  for (let i = 0; i < cells; i++) {
+    const idx = (seed + i) % cells;
+    const px = idx % HOME_GRID;
+    const py = (idx - px) / HOME_GRID;
+    if (!home) return { px, py };
+    if (home.obstacles[idx]) continue;
+    if (home.resources.some((r) => r.px === px && r.py === py)) continue;
+    return { px, py };
+  }
+  return { px: 0, py: 0 };
+}
+
+function hashString(s: string): number {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}

--- a/lib/render/scenes/WorldScene.ts
+++ b/lib/render/scenes/WorldScene.ts
@@ -44,6 +44,7 @@ type NpcView = {
 export class WorldScene extends Phaser.Scene {
   private tileLayer!: Phaser.GameObjects.Graphics;
   private selectionRing!: Phaser.GameObjects.Graphics;
+  private homeMarker!: Phaser.GameObjects.Graphics;
   private npcLayer!: Phaser.GameObjects.Container;
   private npcViews = new Map<string, NpcView>();
 
@@ -69,6 +70,8 @@ export class WorldScene extends Phaser.Scene {
     this.drawTiles();
 
     this.npcLayer = this.add.container(0, 0);
+    this.homeMarker = this.add.graphics();
+    this.homeMarker.setVisible(false);
     this.selectionRing = this.add.graphics();
     this.selectionRing.setVisible(false);
 
@@ -96,6 +99,12 @@ export class WorldScene extends Phaser.Scene {
 
   update(_time: number, delta: number) {
     const store = useGameStore.getState();
+
+    if (store.view === "home") {
+      this.scene.start("Home");
+      return;
+    }
+
     if (!store.paused) {
       this.accumulator += delta * store.speed;
       while (this.accumulator >= this.tickStepMs) {
@@ -106,6 +115,7 @@ export class WorldScene extends Phaser.Scene {
     }
 
     this.renderNpcs();
+    this.renderHomeMarker();
   }
 
   private drawTiles() {
@@ -246,6 +256,26 @@ export class WorldScene extends Phaser.Scene {
     }
 
     this.renderSelection();
+  }
+
+  private renderHomeMarker() {
+    const home = useGameStore.getState().world?.home;
+    this.homeMarker.clear();
+    if (!home) {
+      this.homeMarker.setVisible(false);
+      return;
+    }
+    const px = home.rx * REGION + PADDING;
+    const py = home.ry * REGION + PADDING;
+    this.homeMarker.lineStyle(3, COLORS.selection, 0.85);
+    this.homeMarker.strokeRoundedRect(px, py, INNER, INNER, RADIUS);
+    const cx = home.rx * REGION + REGION / 2;
+    const cy = home.ry * REGION + REGION / 2;
+    const size = 18;
+    this.homeMarker.fillStyle(COLORS.selection, 0.9);
+    this.homeMarker.fillTriangle(cx, cy - size * 0.7, cx - size * 0.7, cy, cx + size * 0.7, cy);
+    this.homeMarker.fillRect(cx - size * 0.5, cy - size * 0.05, size, size * 0.55);
+    this.homeMarker.setVisible(true);
   }
 
   // Draws a single coral outline around either the selected NPC or the

--- a/lib/sim/home.ts
+++ b/lib/sim/home.ts
@@ -1,0 +1,269 @@
+import type { Biome } from "@/lib/sim/biome";
+import type { Rng } from "@/lib/sim/rng";
+import { bfs, isReachable } from "@/lib/sim/path";
+import {
+  BASE_SPEED_TICKS_PER_TILE,
+  ENERGY_MAX,
+  ENERGY_REGEN_TICKS,
+  type PendingAction,
+  type Player,
+} from "@/lib/sim/player";
+import { BIOME_RESOURCES, type ResourceKind } from "@/content/home-resources";
+
+export const HOME_GRID = 10;
+export const RESOURCE_COUNT = 14;
+export const RESOURCE_RESPAWN_TICKS = 240;
+export const OBSTACLE_DENSITY = 0.12;
+
+export type HomeResource = {
+  id: string;
+  px: number;
+  py: number;
+  kind: ResourceKind;
+  respawnAt: number | null;
+};
+
+export type HomeBase = {
+  rx: number;
+  ry: number;
+  biome: Biome;
+  obstacles: boolean[];
+  resources: HomeResource[];
+};
+
+export type Inventory = Partial<Record<ResourceKind, number>>;
+
+export function createHome(
+  rng: Rng,
+  biome: Biome,
+  rx: number,
+  ry: number,
+): { home: HomeBase; player: Player } {
+  const cells = HOME_GRID * HOME_GRID;
+  const spawn = { px: Math.floor(HOME_GRID / 2), py: Math.floor(HOME_GRID / 2) };
+  const obstacleTarget = Math.floor(cells * OBSTACLE_DENSITY);
+
+  let obstacles: boolean[] = [];
+  let resources: HomeResource[] = [];
+
+  for (let attempt = 0; attempt < 32; attempt++) {
+    obstacles = scatterObstacles(rng, spawn, obstacleTarget);
+    if (!spawnSurroundedByObstacles(obstacles, spawn)) {
+      resources = scatterResources(rng, biome, obstacles, spawn);
+      if (resources.length === RESOURCE_COUNT) break;
+    }
+  }
+
+  const player: Player = {
+    px: spawn.px,
+    py: spawn.py,
+    energy: ENERGY_MAX,
+    energyMax: ENERGY_MAX,
+    energyRegenAccum: 0,
+    stats: { speed: BASE_SPEED_TICKS_PER_TILE },
+    route: null,
+    stepCooldown: 0,
+    pendingAction: null,
+  };
+
+  return {
+    home: { rx, ry, biome, obstacles, resources },
+    player,
+  };
+}
+
+export function tickHome(
+  ticks: number,
+  home: HomeBase,
+  player: Player,
+  inventory: Inventory,
+): { home: HomeBase; player: Player; inventory: Inventory } {
+  let nextHome = home;
+  let nextPlayer = player;
+  let nextInventory = inventory;
+
+  // Energy regen.
+  if (nextPlayer.energy < nextPlayer.energyMax) {
+    const accum = nextPlayer.energyRegenAccum + 1;
+    if (accum >= ENERGY_REGEN_TICKS) {
+      nextPlayer = {
+        ...nextPlayer,
+        energy: Math.min(nextPlayer.energyMax, nextPlayer.energy + 1),
+        energyRegenAccum: 0,
+      };
+    } else {
+      nextPlayer = { ...nextPlayer, energyRegenAccum: accum };
+    }
+  }
+
+  // Resource respawn.
+  let resourcesChanged = false;
+  const respawned = nextHome.resources.map((r) => {
+    if (r.respawnAt !== null && ticks >= r.respawnAt) {
+      resourcesChanged = true;
+      return { ...r, respawnAt: null };
+    }
+    return r;
+  });
+  if (resourcesChanged) nextHome = { ...nextHome, resources: respawned };
+
+  // Walk one step if the cooldown is up.
+  if (nextPlayer.route && nextPlayer.route.length > 0) {
+    if (nextPlayer.stepCooldown > 0) {
+      nextPlayer = { ...nextPlayer, stepCooldown: nextPlayer.stepCooldown - 1 };
+    } else {
+      const [next, ...rest] = nextPlayer.route;
+      if (next) {
+        const remaining = rest.length === 0 ? null : rest;
+        nextPlayer = {
+          ...nextPlayer,
+          px: next.px,
+          py: next.py,
+          route: remaining,
+          stepCooldown: remaining ? Math.max(1, nextPlayer.stats.speed) : 0,
+        };
+      }
+    }
+  }
+
+  // Fire the queued action when we've arrived.
+  if (nextPlayer.route === null && nextPlayer.pendingAction) {
+    const action = nextPlayer.pendingAction;
+    if (action.kind === "collect") {
+      const result = tryCollect(ticks, nextHome, nextPlayer, nextInventory, action.resourceId);
+      nextHome = result.home;
+      nextPlayer = { ...result.player, pendingAction: null };
+      nextInventory = result.inventory;
+    } else {
+      nextPlayer = { ...nextPlayer, pendingAction: null };
+    }
+  }
+
+  return { home: nextHome, player: nextPlayer, inventory: nextInventory };
+}
+
+export function walkTo(
+  home: HomeBase,
+  player: Player,
+  tx: number,
+  ty: number,
+  action: PendingAction | null = null,
+): Player {
+  if (tx === player.px && ty === player.py) {
+    return { ...player, route: null, stepCooldown: 0, pendingAction: action };
+  }
+  const path = bfs(home.obstacles, HOME_GRID, HOME_GRID, player.px, player.py, tx, ty);
+  if (!path || path.length === 0) {
+    return { ...player, pendingAction: null };
+  }
+  return {
+    ...player,
+    route: path,
+    stepCooldown: Math.max(1, player.stats.speed),
+    pendingAction: action,
+  };
+}
+
+export function tryCollect(
+  ticks: number,
+  home: HomeBase,
+  player: Player,
+  inventory: Inventory,
+  resourceId: string,
+): { home: HomeBase; player: Player; inventory: Inventory; ok: boolean } {
+  if (player.energy < 1) return { home, player, inventory, ok: false };
+  const idx = home.resources.findIndex((r) => r.id === resourceId);
+  if (idx < 0) return { home, player, inventory, ok: false };
+  const resource = home.resources[idx]!;
+  if (resource.respawnAt !== null) return { home, player, inventory, ok: false };
+  if (resource.px !== player.px || resource.py !== player.py) {
+    return { home, player, inventory, ok: false };
+  }
+
+  const updated: HomeResource = { ...resource, respawnAt: ticks + RESOURCE_RESPAWN_TICKS };
+  const resources = home.resources.slice();
+  resources[idx] = updated;
+  const nextHome: HomeBase = { ...home, resources };
+  const nextPlayer: Player = { ...player, energy: player.energy - 1 };
+  const nextInventory: Inventory = {
+    ...inventory,
+    [resource.kind]: (inventory[resource.kind] ?? 0) + 1,
+  };
+  return { home: nextHome, player: nextPlayer, inventory: nextInventory, ok: true };
+}
+
+export function resourceAt(home: HomeBase, px: number, py: number): HomeResource | null {
+  return home.resources.find((r) => r.px === px && r.py === py) ?? null;
+}
+
+function scatterObstacles(
+  rng: Rng,
+  spawn: { px: number; py: number },
+  target: number,
+): boolean[] {
+  const cells = HOME_GRID * HOME_GRID;
+  const obstacles = new Array<boolean>(cells).fill(false);
+  let placed = 0;
+  let attempts = 0;
+  while (placed < target && attempts < cells * 4) {
+    attempts++;
+    const px = rng.int(0, HOME_GRID);
+    const py = rng.int(0, HOME_GRID);
+    if (px === spawn.px && py === spawn.py) continue;
+    const idx = py * HOME_GRID + px;
+    if (obstacles[idx]) continue;
+    obstacles[idx] = true;
+    placed++;
+  }
+  return obstacles;
+}
+
+function spawnSurroundedByObstacles(
+  obstacles: boolean[],
+  spawn: { px: number; py: number },
+): boolean {
+  for (const [dx, dy] of [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+  ] as const) {
+    const nx = spawn.px + dx;
+    const ny = spawn.py + dy;
+    if (nx < 0 || ny < 0 || nx >= HOME_GRID || ny >= HOME_GRID) continue;
+    if (!obstacles[ny * HOME_GRID + nx]) return false;
+  }
+  return true;
+}
+
+function scatterResources(
+  rng: Rng,
+  biome: Biome,
+  obstacles: boolean[],
+  spawn: { px: number; py: number },
+): HomeResource[] {
+  const kinds = BIOME_RESOURCES[biome];
+  if (kinds.length === 0) return [];
+  const placed: HomeResource[] = [];
+  let attempts = 0;
+  const maxAttempts = HOME_GRID * HOME_GRID * 4;
+  while (placed.length < RESOURCE_COUNT && attempts < maxAttempts) {
+    attempts++;
+    const px = rng.int(0, HOME_GRID);
+    const py = rng.int(0, HOME_GRID);
+    if (px === spawn.px && py === spawn.py) continue;
+    const idx = py * HOME_GRID + px;
+    if (obstacles[idx]) continue;
+    if (placed.some((r) => r.px === px && r.py === py)) continue;
+    if (!isReachable(obstacles, HOME_GRID, HOME_GRID, spawn.px, spawn.py, px, py)) continue;
+    const kind = rng.pick(kinds);
+    placed.push({
+      id: `r-${placed.length}`,
+      px,
+      py,
+      kind,
+      respawnAt: null,
+    });
+  }
+  return placed;
+}

--- a/lib/sim/path.ts
+++ b/lib/sim/path.ts
@@ -1,0 +1,81 @@
+// 4-neighbour BFS over a small boolean obstacle grid. Returns the path
+// excluding the start cell -- so route[0] is the first step the walker takes.
+// Returns null when the target is unreachable or invalid.
+export function bfs(
+  obstacles: boolean[],
+  w: number,
+  h: number,
+  sx: number,
+  sy: number,
+  tx: number,
+  ty: number,
+): Array<{ px: number; py: number }> | null {
+  if (sx === tx && sy === ty) return [];
+  if (!inBounds(tx, ty, w, h)) return null;
+  if (obstacles[ty * w + tx]) return null;
+
+  const prev = new Int32Array(w * h).fill(-1);
+  const visited = new Uint8Array(w * h);
+  const queue: number[] = [sy * w + sx];
+  visited[sy * w + sx] = 1;
+
+  let found = false;
+  while (queue.length > 0) {
+    const idx = queue.shift()!;
+    const cx = idx % w;
+    const cy = (idx - cx) / w;
+
+    if (cx === tx && cy === ty) {
+      found = true;
+      break;
+    }
+
+    for (const [dx, dy] of NEIGHBOURS) {
+      const nx = cx + dx;
+      const ny = cy + dy;
+      if (!inBounds(nx, ny, w, h)) continue;
+      const nIdx = ny * w + nx;
+      if (visited[nIdx]) continue;
+      if (obstacles[nIdx]) continue;
+      visited[nIdx] = 1;
+      prev[nIdx] = idx;
+      queue.push(nIdx);
+    }
+  }
+
+  if (!found) return null;
+
+  const path: Array<{ px: number; py: number }> = [];
+  let cur = ty * w + tx;
+  while (cur !== sy * w + sx) {
+    const cx = cur % w;
+    const cy = (cur - cx) / w;
+    path.push({ px: cx, py: cy });
+    cur = prev[cur]!;
+    if (cur < 0) return null;
+  }
+  return path.reverse();
+}
+
+export function isReachable(
+  obstacles: boolean[],
+  w: number,
+  h: number,
+  sx: number,
+  sy: number,
+  tx: number,
+  ty: number,
+): boolean {
+  return bfs(obstacles, w, h, sx, sy, tx, ty) !== null;
+}
+
+const NEIGHBOURS: ReadonlyArray<readonly [number, number]> = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+];
+
+function inBounds(x: number, y: number, w: number, h: number): boolean {
+  return x >= 0 && y >= 0 && x < w && y < h;
+}

--- a/lib/sim/player.ts
+++ b/lib/sim/player.ts
@@ -1,0 +1,36 @@
+export type PlayerStats = {
+  // Ticks the walker waits between adjacent steps. Lower = faster.
+  speed: number;
+};
+
+export type PendingAction = { kind: "collect"; resourceId: string };
+
+export type Player = {
+  px: number;
+  py: number;
+  energy: number;
+  energyMax: number;
+  energyRegenAccum: number;
+  stats: PlayerStats;
+  route: Array<{ px: number; py: number }> | null;
+  stepCooldown: number;
+  pendingAction: PendingAction | null;
+};
+
+export const BASE_SPEED_TICKS_PER_TILE = 2;
+export const ENERGY_MAX = 8;
+export const ENERGY_REGEN_TICKS = 20;
+
+export function createPlayer(spawn: { px: number; py: number }): Player {
+  return {
+    px: spawn.px,
+    py: spawn.py,
+    energy: ENERGY_MAX,
+    energyMax: ENERGY_MAX,
+    energyRegenAccum: 0,
+    stats: { speed: BASE_SPEED_TICKS_PER_TILE },
+    route: null,
+    stepCooldown: 0,
+    pendingAction: null,
+  };
+}

--- a/lib/sim/world.ts
+++ b/lib/sim/world.ts
@@ -2,10 +2,13 @@ import { createRng } from "@/lib/sim/rng";
 import { initialFactions, type FactionState } from "@/lib/sim/faction";
 import { spawnNpc, tickNpc, type Npc } from "@/lib/sim/npc";
 import { maybeEmitEvent, type WorldEvent } from "@/lib/sim/events";
+import { createHome, tickHome, type HomeBase, type Inventory } from "@/lib/sim/home";
+import type { Player } from "@/lib/sim/player";
+import { biomeAt, isPassable, type Biome } from "@/lib/sim/biome";
 
 export { biomeAt, isPassable, type Biome } from "@/lib/sim/biome";
 
-export const WORLD_VERSION = 3;
+export const WORLD_VERSION = 4;
 export const MAP_W = 12;
 export const MAP_H = 12;
 export const NPC_COUNT = 14;
@@ -18,6 +21,9 @@ export type World = {
   npcs: Npc[];
   factions: FactionState[];
   recentEvents: WorldEvent[];
+  player: Player | null;
+  home: HomeBase | null;
+  inventory: Inventory;
 };
 
 export function createWorld(seed = Date.now() & 0xffffffff): World {
@@ -32,17 +38,49 @@ export function createWorld(seed = Date.now() & 0xffffffff): World {
     npcs,
     factions: initialFactions(),
     recentEvents: [],
+    player: null,
+    home: null,
+    inventory: {},
+  };
+}
+
+export function claimHome(world: World, rx: number, ry: number): World | null {
+  if (!isPassable(rx, ry, MAP_W, MAP_H)) return null;
+  const biome: Biome = biomeAt(rx, ry);
+  if (biome === "water") return null;
+  const rng = createRng(world.rngState);
+  const { home, player } = createHome(rng, biome, rx, ry);
+  return {
+    ...world,
+    rngState: rng.state(),
+    player,
+    home,
   };
 }
 
 export function tickWorld(world: World): { world: World; event: WorldEvent | null } {
   const rng = createRng(world.rngState);
   const npcs = world.npcs.map((n) => tickNpc(n, rng, MAP_W, MAP_H));
+  const ticks = world.ticks + 1;
+
+  let home = world.home;
+  let player = world.player;
+  let inventory = world.inventory;
+  if (home && player) {
+    const stepped = tickHome(ticks, home, player, inventory);
+    home = stepped.home;
+    player = stepped.player;
+    inventory = stepped.inventory;
+  }
+
   const next: World = {
     ...world,
-    ticks: world.ticks + 1,
+    ticks,
     npcs,
     rngState: rng.state(),
+    home,
+    player,
+    inventory,
   };
   const event = maybeEmitEvent(next, rng);
   if (event) {

--- a/lib/state/game-store.ts
+++ b/lib/state/game-store.ts
@@ -1,14 +1,17 @@
 "use client";
 
 import { create } from "zustand";
-import { createWorld, tickWorld, WORLD_VERSION, type World } from "@/lib/sim/world";
+import { claimHome, createWorld, tickWorld, WORLD_VERSION, type World } from "@/lib/sim/world";
 import { loadWorld, saveWorld } from "@/lib/save/db";
 import { bus } from "@/lib/render/bus";
 import type { WorldEvent } from "@/lib/sim/events";
+import type { PendingAction } from "@/lib/sim/player";
+import { resourceAt, walkTo } from "@/lib/sim/home";
 
 const AUTOSAVE_EVERY_TICKS = 60;
 
 export type SelectedRegion = { rx: number; ry: number };
+export type View = "world" | "home";
 
 type GameStore = {
   world: World | null;
@@ -17,6 +20,8 @@ type GameStore = {
   selectedNpcId: string | null;
   selectedRegion: SelectedRegion | null;
   lastEvent: WorldEvent | null;
+  view: View;
+  homePending: boolean;
 
   startNew: () => void;
   loadFromDisk: (slot: string) => Promise<void>;
@@ -27,6 +32,10 @@ type GameStore = {
   setSpeed: (s: number) => void;
   selectNpc: (id: string | null) => void;
   selectRegion: (region: SelectedRegion | null) => void;
+
+  claimHome: (rx: number, ry: number) => void;
+  setView: (v: View) => void;
+  walkPlayerTo: (px: number, py: number) => void;
 };
 
 export const useGameStore = create<GameStore>((set, get) => ({
@@ -36,6 +45,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
   selectedNpcId: null,
   selectedRegion: null,
   lastEvent: null,
+  view: "world",
+  homePending: false,
 
   startNew: () => {
     set({
@@ -44,16 +55,21 @@ export const useGameStore = create<GameStore>((set, get) => ({
       selectedRegion: null,
       lastEvent: null,
       paused: false,
+      view: "world",
+      homePending: true,
     });
   },
 
   loadFromDisk: async (slot) => {
     const loaded = await loadWorld(slot);
     if (loaded && loaded.version === WORLD_VERSION) {
-      set({ world: loaded });
+      set({
+        world: loaded,
+        view: loaded.home ? "home" : "world",
+        homePending: !loaded.home,
+      });
     } else {
-      // Save predates the current world schema -- start fresh.
-      set({ world: createWorld() });
+      set({ world: createWorld(), view: "world", homePending: true });
     }
   },
 
@@ -83,5 +99,36 @@ export const useGameStore = create<GameStore>((set, get) => ({
   selectRegion: (region) => {
     set({ selectedRegion: region, selectedNpcId: region ? null : get().selectedNpcId });
     if (region) bus.emit("npc:deselected");
+  },
+
+  claimHome: (rx, ry) => {
+    const current = get().world;
+    if (!current) return;
+    const next = claimHome(current, rx, ry);
+    if (!next) return;
+    set({
+      world: next,
+      homePending: false,
+      view: "home",
+      selectedNpcId: null,
+      selectedRegion: null,
+    });
+    void saveWorld("default", next);
+  },
+
+  setView: (v) => {
+    if (v === get().view) return;
+    set({ view: v, selectedNpcId: null, selectedRegion: null });
+    bus.emit("npc:deselected");
+  },
+
+  walkPlayerTo: (px, py) => {
+    const current = get().world;
+    if (!current || !current.home || !current.player) return;
+    const target = resourceAt(current.home, px, py);
+    const action: PendingAction | null =
+      target && target.respawnAt === null ? { kind: "collect", resourceId: target.id } : null;
+    const player = walkTo(current.home, current.player, px, py, action);
+    set({ world: { ...current, player } });
   },
 }));


### PR DESCRIPTION
## Summary

- On a new game, the player is prompted to tap a passable region on the world map to claim it as their home base. Claiming opens an interior 10x10 sub-grid of that biome.
- Inside the home, tap any tile to walk there along a BFS-pathfinded route (avoiding obstacles) at a stat-governed speed. Tap a resource to walk to it and collect on arrival; collecting costs energy which regenerates over ticks.
- NPCs whose world-map region matches the home appear inside the sub-grid as visiting tokens (deterministic position derived from id + tick bucket). They disappear when the NPC moves on. World keeps ticking while in home view.

## What changed

- **Sim layer** (`lib/sim/`): new `home.ts` (sub-grid generation, energy/respawn ticking, walk/collect), `player.ts` (energy + speed stat + queued route), `path.ts` (BFS).
- **Content** (`content/home-resources.ts`): per-biome resource kinds + display swatches. Water is unselectable.
- **World**: `WORLD_VERSION` bumped 3 → 4; `World` gains `player`, `home`, `inventory`. New `claimHome(world, rx, ry)`. `tickWorld` runs `tickHome` when a home exists. Existing dev saves reset cleanly via the existing version gate.
- **Store** (`lib/state/game-store.ts`): new `view: "world" | "home"`, `homePending`, plus actions `claimHome`, `setView`, `walkPlayerTo`.
- **Render**: new `HomeScene` (player avatar with eased walk animation, dotted route line, resource squares with respawn fade, visiting-NPC tokens). `WorldScene` paints a coral home marker on the claimed region and swaps to `HomeScene` when `view` flips. `BootScene` reads initial view from the store. `PhaserGame` registers the new scene.
- **UI**: `RegionPanel` shows a "Claim as home base" button while `homePending` and the region is passable. `HUD` gains a view toggle, an energy pip strip, an inventory chip strip, and a "Tap a region to claim your home base" banner on a fresh game.

## Test plan

- [ ] `/play?new=1`: world loads with the claim-your-home banner.
- [ ] Tap water region → no claim button. Tap forest/grass/sand/stone → "Claim as home base" CTA appears.
- [ ] Claim a region → drops into `HomeScene` with player at center, ~14 resource squares scattered, energy full (8 pips).
- [ ] Tap a non-resource tile across the grid → coral dotted route appears, player walks tile-by-tile around obstacles.
- [ ] Tap an obstacle → no movement.
- [ ] Tap a resource → player walks to it, collect fires on arrival, energy drops by 1, resource greys out, inventory chip strip increments.
- [ ] Wait ~60s (or 4x speed) → energy refills, resources respawn.
- [ ] Toggle HUD view back to world → home region marked with a coral home indicator.
- [ ] Wait until an NPC enters the home region; toggle back → NPC token visible in the sub-grid; tap it → `NpcPanel` opens.
- [ ] Reload `/play` (no `?new=1`) → loads directly into home view at saved player position with same inventory.
- [ ] `npm run typecheck && npm run lint && npm run build` pass.
- [ ] Open the Vercel preview on a phone and verify touch interactions (tap-to-walk, pinch-zoom, panel close) work without browser zoom or rubber-band scroll.

https://claude.ai/code/session_01LENsTq4n8GkchXEgRpPgmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01LENsTq4n8GkchXEgRpPgmL)_