### PR TITLE
Phase 3a: combat foundations, tile-level NPCs, weapons, NPC vs NPC

### DIFF
--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect } from "react";
 import HUD from "@/components/hud/HUD";
 import NpcPanel from "@/components/panels/NpcPanel";
+import NpcContextMenu from "@/components/NpcContextMenu";
 import RegionPanel from "@/components/panels/RegionPanel";
 import InventoryPanel from "@/components/panels/InventoryPanel";
 import TutorialModal from "@/components/TutorialModal";
@@ -48,6 +49,7 @@ function PlayInner() {
       <RecenterButton />
       <FactionLegend />
       <NpcPanel />
+      <NpcContextMenu />
       <RegionPanel />
       <InventoryPanel />
       <EncounterToast />

--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -6,6 +6,8 @@ import { Suspense, useEffect } from "react";
 import HUD from "@/components/hud/HUD";
 import NpcPanel from "@/components/panels/NpcPanel";
 import RegionPanel from "@/components/panels/RegionPanel";
+import InventoryPanel from "@/components/panels/InventoryPanel";
+import TutorialModal from "@/components/TutorialModal";
 import RecenterButton from "@/components/RecenterButton";
 import EncounterToast from "@/components/EncounterToast";
 import FactionLegend from "@/components/FactionLegend";
@@ -47,7 +49,9 @@ function PlayInner() {
       <FactionLegend />
       <NpcPanel />
       <RegionPanel />
+      <InventoryPanel />
       <EncounterToast />
+      <TutorialModal />
     </main>
   );
 }

--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -11,6 +11,7 @@ import InventoryPanel from "@/components/panels/InventoryPanel";
 import TutorialModal from "@/components/TutorialModal";
 import RecenterButton from "@/components/RecenterButton";
 import EncounterToast from "@/components/EncounterToast";
+import EncounterFeed from "@/components/EncounterFeed";
 import FactionLegend from "@/components/FactionLegend";
 import { useGameStore } from "@/lib/state/game-store";
 
@@ -53,6 +54,7 @@ function PlayInner() {
       <RegionPanel />
       <InventoryPanel />
       <EncounterToast />
+      <EncounterFeed />
       <TutorialModal />
     </main>
   );

--- a/components/EncounterFeed.tsx
+++ b/components/EncounterFeed.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { CaretRight, Newspaper, X } from "@phosphor-icons/react/dist/ssr";
+import { useState } from "react";
+import { useGameStore } from "@/lib/state/game-store";
+
+export default function EncounterFeed() {
+  const events = useGameStore((s) => s.world?.recentEvents ?? []);
+  const [open, setOpen] = useState(false);
+
+  if (events.length === 0) return null;
+
+  if (!open) {
+    const latest = events[0]!;
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        aria-label="Open encounter feed"
+        className="tactile pointer-events-auto absolute bottom-2 right-2 z-10 inline-flex max-w-[60vw] items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
+      >
+        <Newspaper size={14} weight="duotone" className="shrink-0 text-[var(--color-fg-muted)]" />
+        <span className="truncate text-xs text-[var(--color-fg)]">
+          {latest.context}
+        </span>
+        <CaretRight size={12} weight="bold" className="shrink-0 text-[var(--color-fg-muted)]" />
+      </button>
+    );
+  }
+
+  return (
+    <aside
+      role="log"
+      aria-label="Encounter feed"
+      className="pointer-events-auto absolute bottom-2 right-2 z-10 flex w-72 max-w-[80vw] flex-col rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-3 shadow-[0_16px_40px_-16px_rgba(44,40,32,0.45)]"
+    >
+      <header className="mb-2 flex items-center justify-between gap-3">
+        <span className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+          Recent events
+        </span>
+        <button
+          aria-label="Close feed"
+          onClick={() => setOpen(false)}
+          className="tactile -my-0.5 -mr-1 inline-flex h-6 w-6 items-center justify-center rounded-full text-[var(--color-fg-muted)] hover:bg-[var(--color-surface-warm)] hover:text-[var(--color-fg)]"
+        >
+          <X size={12} weight="bold" />
+        </button>
+      </header>
+      <ul className="flex max-h-[40vh] flex-col gap-1.5 overflow-y-auto">
+        {events.map((e) => (
+          <li
+            key={e.id}
+            className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-warm)] px-2.5 py-1.5"
+          >
+            <p className="font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+              tick {e.tick} · {e.topic}
+            </p>
+            <p className="mt-0.5 text-xs leading-snug text-[var(--color-fg)]">
+              {e.context}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/components/EncounterFeed.tsx
+++ b/components/EncounterFeed.tsx
@@ -6,9 +6,10 @@ import { useGameStore } from "@/lib/state/game-store";
 
 export default function EncounterFeed() {
   const events = useGameStore((s) => s.world?.recentEvents ?? []);
+  const debugMode = useGameStore((s) => s.debugMode);
   const [open, setOpen] = useState(false);
 
-  if (events.length === 0) return null;
+  if (!debugMode || events.length === 0) return null;
 
   if (!open) {
     const latest = events[0]!;

--- a/components/NpcContextMenu.tsx
+++ b/components/NpcContextMenu.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { Eye, Sword } from "@phosphor-icons/react/dist/ssr";
+import { useEffect, useRef } from "react";
+import { useGameStore } from "@/lib/state/game-store";
+import { findNpc } from "@/lib/sim/world";
+
+const MENU_WIDTH = 168;
+const MENU_HEIGHT = 96;
+const MENU_OFFSET = 16;
+const MENU_PADDING = 12;
+
+export default function NpcContextMenu() {
+  const ctx = useGameStore((s) => s.npcContextMenu);
+  const close = useGameStore((s) => s.closeNpcContextMenu);
+  const attackNpc = useGameStore((s) => s.attackNpc);
+  const selectNpc = useGameStore((s) => s.selectNpc);
+  const world = useGameStore((s) => s.world);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!ctx) return;
+    const handler = (e: MouseEvent | TouchEvent) => {
+      if (!ref.current) return;
+      if (ref.current.contains(e.target as Node)) return;
+      close();
+    };
+    const t = window.setTimeout(() => {
+      window.addEventListener("mousedown", handler);
+      window.addEventListener("touchstart", handler);
+    }, 0);
+    return () => {
+      window.clearTimeout(t);
+      window.removeEventListener("mousedown", handler);
+      window.removeEventListener("touchstart", handler);
+    };
+  }, [ctx, close]);
+
+  if (!ctx || !world) return null;
+  const npc = findNpc(world, ctx.id);
+  if (!npc) return null;
+
+  const vw = typeof window === "undefined" ? 1024 : window.innerWidth;
+  const vh = typeof window === "undefined" ? 768 : window.innerHeight;
+  const left = clamp(ctx.x + MENU_OFFSET, MENU_PADDING, vw - MENU_WIDTH - MENU_PADDING);
+  const top = clamp(ctx.y - MENU_HEIGHT - MENU_OFFSET, MENU_PADDING, vh - MENU_HEIGHT - MENU_PADDING);
+
+  const playerRep = world.playerReputation[npc.factionId] ?? 0;
+  const stance = playerRep < 0 ? "Hostile" : playerRep > 0 ? "Friendly" : "Wary";
+  const factionColor = "#" + npc.factionColor.toString(16).padStart(6, "0");
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      aria-label={`${npc.name} actions`}
+      className="pointer-events-auto absolute z-30 flex flex-col rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-1.5 shadow-[0_16px_40px_-16px_rgba(44,40,32,0.45)]"
+      style={{ left, top, width: MENU_WIDTH }}
+    >
+      <div className="flex items-center gap-2 px-2 py-1.5">
+        <span
+          aria-hidden
+          className="h-2 w-2 shrink-0 rounded-sm border border-[var(--color-border-strong)]"
+          style={{ background: factionColor }}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-[var(--color-fg)]">
+            {npc.name}
+          </div>
+          <div className="font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+            {stance}
+          </div>
+        </div>
+      </div>
+      <div className="my-0.5 h-px bg-[var(--color-border)]" aria-hidden />
+      <button
+        onClick={() => {
+          selectNpc(ctx.id);
+          close();
+        }}
+        className="tactile inline-flex items-center gap-2 rounded-xl px-2 py-2 text-left text-sm text-[var(--color-fg)] hover:bg-[var(--color-surface-warm)]"
+      >
+        <Eye size={14} weight="duotone" className="text-[var(--color-fg-muted)]" />
+        Examine
+      </button>
+      {stance !== "Friendly" && (
+        <button
+          onClick={() => {
+            attackNpc(ctx.id);
+            close();
+          }}
+          className="tactile inline-flex items-center gap-2 rounded-xl px-2 py-2 text-left text-sm text-[var(--color-accent)] hover:bg-[var(--color-surface-warm)]"
+        >
+          <Sword size={14} weight="fill" />
+          Attack
+        </button>
+      )}
+    </div>
+  );
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  if (v < lo) return lo;
+  if (v > hi) return hi;
+  return v;
+}

--- a/components/NpcContextMenu.tsx
+++ b/components/NpcContextMenu.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { Eye, Sword } from "@phosphor-icons/react/dist/ssr";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useGameStore } from "@/lib/state/game-store";
 import { findNpc } from "@/lib/sim/world";
 
-const MENU_WIDTH = 168;
-const MENU_HEIGHT = 96;
+const MENU_WIDTH = 180;
+const MENU_HEIGHT_EST = 152;
 const MENU_OFFSET = 16;
 const MENU_PADDING = 12;
 
@@ -17,6 +17,18 @@ export default function NpcContextMenu() {
   const selectNpc = useGameStore((s) => s.selectNpc);
   const world = useGameStore((s) => s.world);
   const ref = useRef<HTMLDivElement | null>(null);
+  const dragOffset = useRef<{ dx: number; dy: number } | null>(null);
+  const [drag, setDrag] = useState<{ left: number; top: number } | null>(null);
+
+  // Reset drag override whenever the menu opens for a different NPC.
+  const lastIdRef = useRef<string | null>(null);
+  if (ctx?.id !== lastIdRef.current) {
+    lastIdRef.current = ctx?.id ?? null;
+    if (drag !== null) {
+      // Defer the state reset to avoid setState-in-render lint warnings.
+      Promise.resolve().then(() => setDrag(null));
+    }
+  }
 
   useEffect(() => {
     if (!ctx) return;
@@ -36,18 +48,53 @@ export default function NpcContextMenu() {
     };
   }, [ctx, close]);
 
-  if (!ctx || !world) return null;
+  const pos = useMemo(() => {
+    if (!ctx) return null;
+    if (drag) return drag;
+    const vw = typeof window === "undefined" ? 1024 : window.innerWidth;
+    const vh = typeof window === "undefined" ? 768 : window.innerHeight;
+    const placeBelow = ctx.y < vh / 2;
+    let left = ctx.x + MENU_OFFSET;
+    let top = placeBelow ? ctx.y + MENU_OFFSET : ctx.y - MENU_HEIGHT_EST - MENU_OFFSET;
+    left = clamp(left, MENU_PADDING, vw - MENU_WIDTH - MENU_PADDING);
+    top = clamp(top, MENU_PADDING, vh - MENU_HEIGHT_EST - MENU_PADDING);
+    return { left, top };
+  }, [ctx, drag]);
+
+  if (!ctx || !world || !pos) return null;
   const npc = findNpc(world, ctx.id);
   if (!npc) return null;
-
-  const vw = typeof window === "undefined" ? 1024 : window.innerWidth;
-  const vh = typeof window === "undefined" ? 768 : window.innerHeight;
-  const left = clamp(ctx.x + MENU_OFFSET, MENU_PADDING, vw - MENU_WIDTH - MENU_PADDING);
-  const top = clamp(ctx.y - MENU_HEIGHT - MENU_OFFSET, MENU_PADDING, vh - MENU_HEIGHT - MENU_PADDING);
 
   const playerRep = world.playerReputation[npc.factionId] ?? 0;
   const stance = playerRep < 0 ? "Hostile" : playerRep > 0 ? "Friendly" : "Wary";
   const factionColor = "#" + npc.factionColor.toString(16).padStart(6, "0");
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    if (!ref.current) return;
+    const rect = ref.current.getBoundingClientRect();
+    dragOffset.current = { dx: e.clientX - rect.left, dy: e.clientY - rect.top };
+    (e.target as Element).setPointerCapture?.(e.pointerId);
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!dragOffset.current) return;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const left = clamp(
+      e.clientX - dragOffset.current.dx,
+      MENU_PADDING,
+      vw - MENU_WIDTH - MENU_PADDING,
+    );
+    const top = clamp(
+      e.clientY - dragOffset.current.dy,
+      MENU_PADDING,
+      vh - MENU_HEIGHT_EST - MENU_PADDING,
+    );
+    setDrag({ left, top });
+  };
+  const onPointerUp = (e: React.PointerEvent) => {
+    dragOffset.current = null;
+    (e.target as Element).releasePointerCapture?.(e.pointerId);
+  };
 
   return (
     <div
@@ -55,9 +102,15 @@ export default function NpcContextMenu() {
       role="menu"
       aria-label={`${npc.name} actions`}
       className="pointer-events-auto absolute z-30 flex flex-col rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-1.5 shadow-[0_16px_40px_-16px_rgba(44,40,32,0.45)]"
-      style={{ left, top, width: MENU_WIDTH }}
+      style={{ left: pos.left, top: pos.top, width: MENU_WIDTH }}
     >
-      <div className="flex items-center gap-2 px-2 py-1.5">
+      <div
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        className="flex cursor-grab items-center gap-2 px-2 py-1.5 active:cursor-grabbing touch-none select-none"
+      >
         <span
           aria-hidden
           className="h-2 w-2 shrink-0 rounded-sm border border-[var(--color-border-strong)]"
@@ -68,7 +121,7 @@ export default function NpcContextMenu() {
             {npc.name}
           </div>
           <div className="font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
-            {stance}
+            {stance} · drag to move
           </div>
         </div>
       </div>

--- a/components/TutorialModal.tsx
+++ b/components/TutorialModal.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import {
+  ArrowRight,
+  Compass,
+  Footprints,
+  Hammer,
+  Heart,
+  House,
+  Lightning,
+  Package,
+  Sword,
+} from "@phosphor-icons/react/dist/ssr";
+import { useGameStore } from "@/lib/state/game-store";
+
+type Page = {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+};
+
+const PAGES: Page[] = [
+  {
+    icon: <Compass size={28} weight="duotone" className="text-[var(--color-accent)]" />,
+    title: "A small living world",
+    body:
+      "Three factions wander a 32×32 grid of biomes. Their stories happen whether you're watching or not. Your job is to survive, claim a home, and shape the politics around you.",
+  },
+  {
+    icon: <House size={28} weight="duotone" className="text-[var(--color-accent)]" />,
+    title: "Claim a home base",
+    body:
+      "Tap a passable region on the world map to claim it as home. From there you'll forage, craft, and venture out. Pick a region close to forest or stone — you'll need their materials.",
+  },
+  {
+    icon: <Footprints size={28} weight="duotone" className="text-[var(--color-accent)]" />,
+    title: "Walk and travel",
+    body:
+      "Inside a biome, tap a tile to walk to it. Tap a region from the world map and choose Travel here to walk further. The map and biome views toggle from the home button in the top pill.",
+  },
+  {
+    icon: (
+      <span className="inline-flex items-center gap-2">
+        <Heart size={26} weight="fill" className="text-[var(--color-accent)]" />
+        <Lightning size={26} weight="fill" className="text-[var(--color-accent)]" />
+      </span>
+    ),
+    title: "Health and energy",
+    body:
+      "Walking costs energy. At zero energy you start to starve and lose health. Eat foraged food (berries, grain, herbs, shellfish, tubers) to restore both.",
+  },
+  {
+    icon: <Package size={28} weight="duotone" className="text-[var(--color-accent)]" />,
+    title: "Inventory",
+    body:
+      "Tap the inventory pill in the top right to see what you've gathered, what weapons you carry, and what you can craft.",
+  },
+  {
+    icon: <Hammer size={28} weight="duotone" className="text-[var(--color-accent)]" />,
+    title: "Crafting weapons",
+    body:
+      "Open the inventory and craft a stick, club, or sling. Wood comes from forests, stone from rocky regions, reed from grasslands and beaches. Weapons equip implicitly — your strongest in-range weapon swings.",
+  },
+  {
+    icon: <Sword size={28} weight="duotone" className="text-[var(--color-accent)]" />,
+    title: "Combat",
+    body:
+      "Tap an NPC to inspect them. If you tap Attack, you'll lunge at the next opportunity — but you'll lose reputation with their faction, and they'll fight back. Watch for the small pulsing dot in the health pill: that means a hostile is in your region.",
+  },
+];
+
+export default function TutorialModal() {
+  const open = useGameStore((s) => s.tutorialOpen);
+  const close = useGameStore((s) => s.closeTutorial);
+  const [page, setPage] = useState(0);
+
+  if (!open) return null;
+  const current = PAGES[page]!;
+  const last = page === PAGES.length - 1;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="How to play"
+      className="pointer-events-auto absolute inset-0 z-30 flex items-center justify-center bg-[rgba(44,40,32,0.55)] p-6"
+    >
+      <div className="flex max-h-[80dvh] w-full max-w-md flex-col rounded-3xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6 shadow-[0_24px_64px_-24px_rgba(44,40,32,0.5)]">
+        <div className="flex items-start gap-3">
+          <span aria-hidden className="mt-0.5">
+            {current.icon}
+          </span>
+          <div>
+            <p className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+              {page + 1} of {PAGES.length}
+            </p>
+            <h2 className="mt-1 text-xl font-medium leading-tight text-[var(--color-fg)]">
+              {current.title}
+            </h2>
+          </div>
+        </div>
+
+        <p className="mt-4 text-sm leading-relaxed text-[var(--color-fg-muted)] max-w-[60ch]">
+          {current.body}
+        </p>
+
+        <div className="mt-auto flex items-center justify-between pt-6">
+          <button
+            onClick={() => {
+              setPage(0);
+              close();
+            }}
+            className="tactile inline-flex items-center justify-center rounded-full px-3 py-2 text-sm text-[var(--color-fg-muted)] hover:bg-[var(--color-surface-warm)]"
+          >
+            Skip
+          </button>
+          <div className="flex items-center gap-2">
+            {page > 0 && (
+              <button
+                onClick={() => setPage(page - 1)}
+                className="tactile inline-flex items-center justify-center rounded-full border border-[var(--color-border)] px-3 py-2 text-sm text-[var(--color-fg)] hover:bg-[var(--color-surface-warm)]"
+              >
+                Back
+              </button>
+            )}
+            <button
+              onClick={() => {
+                if (last) {
+                  setPage(0);
+                  close();
+                } else {
+                  setPage(page + 1);
+                }
+              }}
+              className="tactile inline-flex items-center justify-center gap-1 rounded-2xl bg-[var(--color-accent)] px-4 py-2.5 text-sm font-medium text-[var(--color-bg)] shadow-[0_8px_24px_-12px_rgba(217,104,70,0.5)]"
+            >
+              {last ? "Begin" : "Next"}
+              {!last && <ArrowRight size={14} weight="bold" />}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/hud/HUD.tsx
+++ b/components/hud/HUD.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import {
   Bug,
+  Eye,
+  EyeSlash,
   House,
   Pause,
   Play,
@@ -52,6 +54,8 @@ export default function HUD() {
   const openInventory = useGameStore((s) => s.openInventory);
   const debugMode = useGameStore((s) => s.debugMode);
   const toggleDebug = useGameStore((s) => s.toggleDebug);
+  const mapShowFactions = useGameStore((s) => s.mapShowFactions);
+  const toggleMapFactions = useGameStore((s) => s.toggleMapFactions);
 
   return (
     <>
@@ -105,6 +109,28 @@ export default function HUD() {
                   <MapTrifold size={16} weight="duotone" />
                 ) : (
                   <House size={16} weight="duotone" />
+                )}
+              </button>
+            </>
+          )}
+
+          {view === "world" && (
+            <>
+              <span className="mx-1 h-4 w-px bg-[var(--color-border)]" aria-hidden />
+              <button
+                aria-label={
+                  mapShowFactions ? "Hide faction zones" : "Show faction zones"
+                }
+                aria-pressed={mapShowFactions}
+                onClick={toggleMapFactions}
+                className={`tactile inline-flex h-8 w-8 items-center justify-center rounded-full hover:bg-[var(--color-surface-warm)] ${
+                  mapShowFactions ? "text-[var(--color-fg)]" : "text-[var(--color-fg-muted)]"
+                }`}
+              >
+                {mapShowFactions ? (
+                  <Eye size={16} weight="duotone" />
+                ) : (
+                  <EyeSlash size={16} weight="duotone" />
                 )}
               </button>
             </>

--- a/components/hud/HUD.tsx
+++ b/components/hud/HUD.tsx
@@ -12,6 +12,9 @@ import {
 } from "@phosphor-icons/react/dist/ssr";
 import { useGameStore } from "@/lib/state/game-store";
 import { RESOURCES, type ResourceKind } from "@/content/resources";
+import { globalToLocal } from "@/lib/sim/biome-interior";
+import type { GameOverReason } from "@/lib/sim/world";
+import { findFaction } from "@/lib/sim/faction";
 
 const SPEEDS = [1, 2, 4] as const;
 
@@ -28,6 +31,22 @@ export default function HUD() {
   const player = useGameStore((s) => s.world?.player ?? null);
   const inventory = useGameStore((s) => s.world?.inventory ?? {});
   const gameOver = useGameStore((s) => s.world?.gameOver ?? false);
+  const gameOverReason = useGameStore((s) => s.world?.gameOverReason ?? null);
+  const inCombat = useGameStore((s) => {
+    const w = s.world;
+    if (!w?.player) return false;
+    const here = globalToLocal(w.player.gx, w.player.gy);
+    for (const n of w.npcs) {
+      if (n.rx !== here.rx || n.ry !== here.ry) continue;
+      if ((w.playerReputation[n.factionId] ?? 0) < 0) return true;
+    }
+    return false;
+  });
+  const killerFactionName = useGameStore((s) => {
+    const w = s.world;
+    if (!w || !w.gameOverReason || w.gameOverReason === "starved") return null;
+    return findFaction(w.factions, w.gameOverReason.factionId)?.name ?? null;
+  });
   const resetAfterDeath = useGameStore((s) => s.resetAfterDeath);
 
   return (
@@ -99,7 +118,7 @@ export default function HUD() {
 
       {player && (
         <div className="pointer-events-none absolute inset-x-2 top-16 z-10 flex flex-wrap items-center justify-end gap-2">
-          <HealthStrip health={player.health} max={player.healthMax} />
+          <HealthStrip health={player.health} max={player.healthMax} inCombat={inCombat} />
           <EnergyStrip energy={player.energy} max={player.energyMax} />
           {view === "biome" && <InventoryStrip inventory={inventory} />}
         </div>
@@ -112,10 +131,10 @@ export default function HUD() {
               The end of one life
             </p>
             <h2 className="mt-2 text-[1.75rem] font-medium tracking-tight leading-[1.05] text-[var(--color-fg)]">
-              You died.
+              {gameOverHeadline(gameOverReason)}
             </h2>
             <p className="mt-3 text-sm leading-relaxed text-[var(--color-fg-muted)] max-w-[34ch] mx-auto">
-              The world remembers. Begin a new life and the land itself will be different.
+              {gameOverBody(gameOverReason, killerFactionName)}
             </p>
             <button
               onClick={resetAfterDeath}
@@ -130,10 +149,42 @@ export default function HUD() {
   );
 }
 
-function HealthStrip({ health, max }: { health: number; max: number }) {
+function gameOverHeadline(reason: GameOverReason | null): string {
+  if (!reason || reason === "starved") return "You starved.";
+  return `Killed by ${reason.killerName}.`;
+}
+
+function gameOverBody(
+  reason: GameOverReason | null,
+  factionName: string | null,
+): string {
+  if (!reason || reason === "starved") {
+    return "Hunger took the rest. The land remembers; begin a new life.";
+  }
+  if (factionName) {
+    return `A blade of the ${factionName} ended this run. The world remembers; begin a new life.`;
+  }
+  return "The world remembers; begin a new life.";
+}
+
+function HealthStrip({
+  health,
+  max,
+  inCombat,
+}: {
+  health: number;
+  max: number;
+  inCombat: boolean;
+}) {
   const low = health > 0 && health <= Math.ceil(max / 2);
   return (
     <div className="pointer-events-auto inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]">
+      {inCombat && (
+        <span
+          aria-hidden
+          className="h-1.5 w-1.5 rounded-full bg-[var(--color-accent)] animate-pulse"
+        />
+      )}
       <Heart
         size={14}
         weight="fill"

--- a/components/hud/HUD.tsx
+++ b/components/hud/HUD.tsx
@@ -187,6 +187,8 @@ function gameOverBody(
 
 function DebugStrip() {
   const world = useGameStore((s) => s.world);
+  const minimized = useGameStore((s) => s.debugMinimized);
+  const toggleMinimized = useGameStore((s) => s.toggleDebugMinimized);
   if (!world) return null;
   const player = world.player;
   const here = player ? globalToLocal(player.gx, player.gy) : null;
@@ -198,13 +200,36 @@ function DebugStrip() {
     pwr: f.power,
     rep: world.playerReputation[f.id] ?? 0,
   }));
+
+  if (minimized) {
+    return (
+      <button
+        onClick={toggleMinimized}
+        aria-label="Expand debug overlay"
+        className="tactile pointer-events-auto absolute bottom-2 left-2 z-10 inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg)] shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
+      >
+        <Bug size={12} weight="fill" className="text-[var(--color-accent)]" />
+        Debug · {world.npcs.length} npcs
+      </button>
+    );
+  }
+
   return (
     <aside
       role="status"
       aria-label="Debug stats"
-      className="pointer-events-none absolute left-2 top-16 z-10 max-w-[60vw] rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 font-mono text-[10px] leading-tight text-[var(--color-fg)] shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
+      className="pointer-events-auto absolute bottom-2 left-2 z-10 max-w-[70vw] rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 font-mono text-[10px] leading-tight text-[var(--color-fg)] shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
     >
-      <div className="text-[var(--color-fg-muted)] uppercase tracking-wider">Debug</div>
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-[var(--color-fg-muted)] uppercase tracking-wider">Debug</span>
+        <button
+          onClick={toggleMinimized}
+          aria-label="Minimize debug overlay"
+          className="tactile -my-0.5 -mr-1 inline-flex h-5 w-5 items-center justify-center rounded-full text-[var(--color-fg-muted)] hover:bg-[var(--color-surface-warm)] hover:text-[var(--color-fg)]"
+        >
+          –
+        </button>
+      </div>
       <div className="mt-1 grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
         <span className="text-[var(--color-fg-muted)]">npcs</span>
         <span className="tabular-nums">{world.npcs.length}</span>

--- a/components/hud/HUD.tsx
+++ b/components/hud/HUD.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import {
+  Bug,
   House,
   Pause,
   Play,
@@ -48,6 +49,9 @@ export default function HUD() {
     return findFaction(w.factions, w.gameOverReason.factionId)?.name ?? null;
   });
   const resetAfterDeath = useGameStore((s) => s.resetAfterDeath);
+  const openInventory = useGameStore((s) => s.openInventory);
+  const debugMode = useGameStore((s) => s.debugMode);
+  const toggleDebug = useGameStore((s) => s.toggleDebug);
 
   return (
     <>
@@ -105,8 +109,22 @@ export default function HUD() {
               </button>
             </>
           )}
+
+          <span className="mx-1 h-4 w-px bg-[var(--color-border)]" aria-hidden />
+          <button
+            aria-label={debugMode ? "Hide debug overlay" : "Show debug overlay"}
+            aria-pressed={debugMode}
+            onClick={toggleDebug}
+            className={`tactile inline-flex h-8 w-8 items-center justify-center rounded-full hover:bg-[var(--color-surface-warm)] ${
+              debugMode ? "text-[var(--color-accent)]" : "text-[var(--color-fg-muted)]"
+            }`}
+          >
+            <Bug size={16} weight={debugMode ? "fill" : "regular"} />
+          </button>
         </div>
       </header>
+
+      {debugMode && <DebugStrip />}
 
       {homePending && view === "world" && (
         <div className="pointer-events-none absolute inset-x-0 top-16 z-10 flex justify-center px-3">
@@ -120,7 +138,7 @@ export default function HUD() {
         <div className="pointer-events-none absolute inset-x-2 top-16 z-10 flex flex-wrap items-center justify-end gap-2">
           <HealthStrip health={player.health} max={player.healthMax} inCombat={inCombat} />
           <EnergyStrip energy={player.energy} max={player.energyMax} />
-          {view === "biome" && <InventoryStrip inventory={inventory} />}
+          <InventoryStrip inventory={inventory} onOpen={openInventory} />
         </div>
       )}
 
@@ -165,6 +183,56 @@ function gameOverBody(
     return `A blade of the ${factionName} ended this run. The world remembers; begin a new life.`;
   }
   return "The world remembers; begin a new life.";
+}
+
+function DebugStrip() {
+  const world = useGameStore((s) => s.world);
+  if (!world) return null;
+  const player = world.player;
+  const here = player ? globalToLocal(player.gx, player.gy) : null;
+  const inRegion = here
+    ? world.npcs.filter((n) => n.rx === here.rx && n.ry === here.ry).length
+    : 0;
+  const factionLines = world.factions.map((f) => ({
+    id: f.id,
+    pwr: f.power,
+    rep: world.playerReputation[f.id] ?? 0,
+  }));
+  return (
+    <aside
+      role="status"
+      aria-label="Debug stats"
+      className="pointer-events-none absolute left-2 top-16 z-10 max-w-[60vw] rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 font-mono text-[10px] leading-tight text-[var(--color-fg)] shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
+    >
+      <div className="text-[var(--color-fg-muted)] uppercase tracking-wider">Debug</div>
+      <div className="mt-1 grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
+        <span className="text-[var(--color-fg-muted)]">npcs</span>
+        <span className="tabular-nums">{world.npcs.length}</span>
+        <span className="text-[var(--color-fg-muted)]">tick</span>
+        <span className="tabular-nums">{world.ticks}</span>
+        {player && here && (
+          <>
+            <span className="text-[var(--color-fg-muted)]">player</span>
+            <span className="tabular-nums">
+              g({player.gx},{player.gy}) r({here.rx},{here.ry})
+            </span>
+            <span className="text-[var(--color-fg-muted)]">in-region</span>
+            <span className="tabular-nums">{inRegion}</span>
+          </>
+        )}
+      </div>
+      <div className="mt-1 border-t border-[var(--color-border)] pt-1">
+        {factionLines.map((f) => (
+          <div key={f.id} className="flex justify-between gap-4">
+            <span className="text-[var(--color-fg-muted)]">{f.id}</span>
+            <span className="tabular-nums">
+              pwr {f.pwr} · rep {f.rep}
+            </span>
+          </div>
+        ))}
+      </div>
+    </aside>
+  );
 }
 
 function HealthStrip({
@@ -240,25 +308,40 @@ function EnergyStrip({ energy, max }: { energy: number; max: number }) {
   );
 }
 
-function InventoryStrip({ inventory }: { inventory: Partial<Record<ResourceKind, number>> }) {
+function InventoryStrip({
+  inventory,
+  onOpen,
+}: {
+  inventory: Partial<Record<ResourceKind, number>>;
+  onOpen: () => void;
+}) {
   const entries = (Object.entries(inventory) as Array<[ResourceKind, number]>).filter(
     ([, n]) => n > 0,
   );
-  if (entries.length === 0) return null;
   return (
-    <div className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]">
-      {entries.map(([kind, count]) => (
-        <span key={kind} className="inline-flex items-center gap-1">
-          <span
-            aria-hidden
-            className="h-2.5 w-2.5 rounded-full border border-[var(--color-border-strong)]"
-            style={{ background: RESOURCES[kind].swatch }}
-          />
-          <span className="font-mono text-[10px] tabular-nums text-[var(--color-fg)]">
-            {count}
-          </span>
+    <button
+      onClick={onOpen}
+      aria-label="Open inventory"
+      className="tactile pointer-events-auto inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
+    >
+      {entries.length === 0 ? (
+        <span className="font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+          Inventory
         </span>
-      ))}
-    </div>
+      ) : (
+        entries.map(([kind, count]) => (
+          <span key={kind} className="inline-flex items-center gap-1">
+            <span
+              aria-hidden
+              className="h-2.5 w-2.5 rounded-full border border-[var(--color-border-strong)]"
+              style={{ background: RESOURCES[kind].swatch }}
+            />
+            <span className="font-mono text-[10px] tabular-nums text-[var(--color-fg)]">
+              {count}
+            </span>
+          </span>
+        ))
+      )}
+    </button>
   );
 }

--- a/components/panels/InventoryPanel.tsx
+++ b/components/panels/InventoryPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Hammer, Knife, Package, X } from "@phosphor-icons/react/dist/ssr";
+import { ForkKnife, Hammer, Knife, Package, X } from "@phosphor-icons/react/dist/ssr";
 import { useGameStore } from "@/lib/state/game-store";
 import { RESOURCES, type ResourceKind } from "@/content/resources";
 import {
@@ -15,6 +15,7 @@ export default function InventoryPanel() {
   const close = useGameStore((s) => s.closeInventory);
   const world = useGameStore((s) => s.world);
   const craft = useGameStore((s) => s.craft);
+  const eatFood = useGameStore((s) => s.eatFood);
 
   if (!open || !world) return null;
 
@@ -67,7 +68,7 @@ export default function InventoryPanel() {
               the biome to collect them.
             </p>
           ) : (
-            <ul className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3">
+            <ul className="mt-3 flex flex-col gap-2">
               {entries.map(([kind, count]) => {
                 const meta = RESOURCES[kind];
                 return (
@@ -82,10 +83,25 @@ export default function InventoryPanel() {
                     />
                     <span className="flex-1 text-sm text-[var(--color-fg)]">
                       {meta.label}
+                      {meta.food && (
+                        <span className="ml-2 font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+                          food · +energy +hp
+                        </span>
+                      )}
                     </span>
                     <span className="font-mono text-[11px] tabular-nums text-[var(--color-fg-muted)]">
                       {count}
                     </span>
+                    {meta.food && (
+                      <button
+                        onClick={() => eatFood(kind)}
+                        disabled={!player || world.gameOver}
+                        className="tactile inline-flex items-center gap-1 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1 font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg)] disabled:opacity-50"
+                      >
+                        <ForkKnife size={12} weight="fill" className="text-[var(--color-accent)]" />
+                        Eat
+                      </button>
+                    )}
                   </li>
                 );
               })}

--- a/components/panels/InventoryPanel.tsx
+++ b/components/panels/InventoryPanel.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { Hammer, Knife, Package, X } from "@phosphor-icons/react/dist/ssr";
+import { useGameStore } from "@/lib/state/game-store";
+import { RESOURCES, type ResourceKind } from "@/content/resources";
+import {
+  WEAPONS,
+  WEAPON_KINDS,
+  type WeaponKind,
+} from "@/content/weapons";
+import { affordable } from "@/lib/sim/weapons";
+
+export default function InventoryPanel() {
+  const open = useGameStore((s) => s.inventoryOpen);
+  const close = useGameStore((s) => s.closeInventory);
+  const world = useGameStore((s) => s.world);
+  const craft = useGameStore((s) => s.craft);
+
+  if (!open || !world) return null;
+
+  const inventory = world.inventory;
+  const player = world.player;
+  const entries = (Object.entries(inventory) as Array<[ResourceKind, number]>).filter(
+    ([, n]) => n > 0,
+  );
+
+  return (
+    <aside
+      role="dialog"
+      aria-label="Inventory"
+      className="pointer-events-auto absolute inset-x-2 bottom-2 z-20 max-h-[68dvh] overflow-y-auto rounded-3xl border border-[var(--color-border)] bg-[var(--color-surface)] p-5 shadow-[0_20px_48px_-20px_rgba(44,40,32,0.25)]"
+    >
+      <div className="mx-auto max-w-2xl">
+        <header className="mb-4 flex items-start justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <span
+              aria-hidden
+              className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-warm)]"
+            >
+              <Package size={18} weight="duotone" className="text-[var(--color-fg)]" />
+            </span>
+            <div>
+              <h2 className="text-lg font-medium leading-tight text-[var(--color-fg)]">
+                Inventory
+              </h2>
+              <p className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+                What you carry
+              </p>
+            </div>
+          </div>
+          <button
+            aria-label="Close"
+            onClick={close}
+            className="tactile inline-flex h-9 w-9 items-center justify-center rounded-full text-[var(--color-fg-muted)] hover:bg-[var(--color-surface-warm)] hover:text-[var(--color-fg)]"
+          >
+            <X size={18} weight="bold" />
+          </button>
+        </header>
+
+        <section className="border-t border-[var(--color-border)] pt-4">
+          <h3 className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+            Materials & food
+          </h3>
+          {entries.length === 0 ? (
+            <p className="mt-2 text-sm text-[var(--color-fg-muted)]">
+              You haven&apos;t gathered anything yet. Tap food and material dots in
+              the biome to collect them.
+            </p>
+          ) : (
+            <ul className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {entries.map(([kind, count]) => {
+                const meta = RESOURCES[kind];
+                return (
+                  <li
+                    key={kind}
+                    className="flex items-center gap-2.5 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-warm)] px-3 py-2"
+                  >
+                    <span
+                      aria-hidden
+                      className="h-3 w-3 shrink-0 rounded-full border border-[var(--color-border-strong)]"
+                      style={{ background: meta.swatch }}
+                    />
+                    <span className="flex-1 text-sm text-[var(--color-fg)]">
+                      {meta.label}
+                    </span>
+                    <span className="font-mono text-[11px] tabular-nums text-[var(--color-fg-muted)]">
+                      {count}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+
+        {player && player.weapons.length > 0 && (
+          <section className="mt-5 border-t border-[var(--color-border)] pt-4">
+            <h3 className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+              Weapons
+            </h3>
+            <ul className="mt-3 flex flex-col gap-2">
+              {player.weapons.map((w, i) => {
+                const meta = WEAPONS[w.kind];
+                return (
+                  <li
+                    key={`${w.kind}-${i}`}
+                    className="flex items-center gap-3 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-warm)] px-3 py-2"
+                  >
+                    <Knife size={16} weight="fill" className="text-[var(--color-accent)]" />
+                    <span className="flex-1 text-sm text-[var(--color-fg)]">
+                      {meta.label}
+                    </span>
+                    <span className="font-mono text-[10px] uppercase tracking-wider tabular-nums text-[var(--color-fg-muted)]">
+                      +{meta.attack} atk · reach {meta.reach}
+                      {meta.ranged ? " · ranged" : ""}
+                    </span>
+                    <span className="font-mono text-[11px] tabular-nums text-[var(--color-fg-muted)]">
+                      {w.usesLeft}/{meta.durability}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        )}
+
+        <section className="mt-5 border-t border-[var(--color-border)] pt-4">
+          <h3 className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+            Crafting
+          </h3>
+          <ul className="mt-3 flex flex-col gap-2">
+            {WEAPON_KINDS.map((kind: WeaponKind) => {
+              const meta = WEAPONS[kind];
+              const can = Boolean(player) && !world.gameOver && affordable(inventory, kind);
+              return (
+                <li key={kind}>
+                  <button
+                    onClick={() => craft(kind)}
+                    disabled={!can}
+                    className="tactile flex w-full items-center gap-3 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-warm)] px-3 py-2 text-left disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <Hammer
+                      size={16}
+                      weight={can ? "fill" : "regular"}
+                      className="shrink-0 text-[var(--color-accent)]"
+                    />
+                    <span className="flex-1">
+                      <span className="block text-sm font-medium text-[var(--color-fg)]">
+                        {meta.label}
+                      </span>
+                      <span className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+                        <span>+{meta.attack} atk</span>
+                        <span>reach {meta.reach}</span>
+                        {meta.ranged && <span>ranged</span>}
+                        <span>· uses {meta.durability}</span>
+                      </span>
+                      <span className="mt-1 flex flex-wrap gap-1.5">
+                        {(Object.entries(meta.recipe) as Array<[
+                          ResourceKind,
+                          number,
+                        ]>).map(([k, n]) => (
+                          <RecipePip
+                            key={k}
+                            kind={k}
+                            need={n}
+                            have={inventory[k] ?? 0}
+                          />
+                        ))}
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+
+        <section className="mt-5 border-t border-[var(--color-border)] pt-4">
+          <h3 className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+            Gear (coming soon)
+          </h3>
+          <p className="mt-2 text-sm text-[var(--color-fg-muted)]">
+            Tools, armour, and trinkets land with the workbench in Phase 4.
+          </p>
+        </section>
+      </div>
+    </aside>
+  );
+}
+
+function RecipePip({
+  kind,
+  need,
+  have,
+}: {
+  kind: ResourceKind;
+  need: number;
+  have: number;
+}) {
+  const ok = have >= need;
+  return (
+    <span
+      className="inline-flex items-center gap-1 font-mono text-[10px] tabular-nums"
+      style={{ color: ok ? "var(--color-fg)" : "var(--color-fg-muted)" }}
+    >
+      <span
+        aria-hidden
+        className="h-2 w-2 rounded-full border border-[var(--color-border-strong)]"
+        style={{ background: RESOURCES[kind].swatch }}
+      />
+      {RESOURCES[kind].label} {have}/{need}
+    </span>
+  );
+}

--- a/components/panels/NpcPanel.tsx
+++ b/components/panels/NpcPanel.tsx
@@ -1,27 +1,56 @@
 "use client";
 
-import { X } from "@phosphor-icons/react/dist/ssr";
+import { Sword, X } from "@phosphor-icons/react/dist/ssr";
 import { useGameStore } from "@/lib/state/game-store";
 import { findNpc } from "@/lib/sim/world";
 import type { Npc } from "@/lib/sim/npc";
 import type { Goal } from "@/lib/sim/goal";
+import type { Player } from "@/lib/sim/player";
 import { FACTIONS } from "@/content/factions";
 import { RESOURCES } from "@/content/resources";
 import ShapeBadge from "@/components/panels/ShapeBadge";
+import { globalToLocal } from "@/lib/sim/biome-interior";
+import { pickWeaponForRange, weaponAttackBonus, weaponReach } from "@/lib/sim/weapons";
+import { WEAPONS } from "@/content/weapons";
 
 export default function NpcPanel() {
   const selectedId = useGameStore((s) => s.selectedNpcId);
   const world = useGameStore((s) => s.world);
+  const attackNpc = useGameStore((s) => s.attackNpc);
   const npc = world && selectedId ? findNpc(world, selectedId) : undefined;
 
   if (!npc || !world) return null;
-  return <NpcPanelInner npc={npc} npcs={world.npcs} />;
+  return (
+    <NpcPanelInner
+      npc={npc}
+      npcs={world.npcs}
+      player={world.player}
+      playerRep={world.playerReputation[npc.factionId] ?? 0}
+      onAttack={() => attackNpc(npc.id)}
+    />
+  );
 }
 
-function NpcPanelInner({ npc, npcs }: { npc: Npc; npcs: Npc[] }) {
+function NpcPanelInner({
+  npc,
+  npcs,
+  player,
+  playerRep,
+  onAttack,
+}: {
+  npc: Npc;
+  npcs: Npc[];
+  player: Player | null;
+  playerRep: number;
+  onAttack: () => void;
+}) {
   const select = useGameStore((s) => s.selectNpc);
   const factionColorHex = "#" + npc.factionColor.toString(16).padStart(6, "0");
   const shape = FACTIONS.find((f) => f.id === npc.factionId)?.shape ?? "diamond";
+
+  const sentiment: "hostile" | "wary" | "friendly" =
+    playerRep < 0 ? "hostile" : playerRep > 0 ? "friendly" : "wary";
+  const matchup = computeMatchup(player, npc);
 
   return (
     <aside
@@ -81,10 +110,64 @@ function NpcPanelInner({ npc, npcs }: { npc: Npc; npcs: Npc[] }) {
               </span>
             ))}
           </dd>
+
+          <dt className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+            Stance
+          </dt>
+          <dd className="text-sm text-[var(--color-fg)] capitalize">{sentiment}</dd>
+
+          <dt className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+            Combat
+          </dt>
+          <dd className="text-sm text-[var(--color-fg)]">
+            <span className="font-mono tabular-nums">
+              atk {npc.combatAttack} · def {npc.combatDefense} · hp {npc.combatHealth}/{npc.combatHealthMax}
+            </span>
+          </dd>
+
+          {matchup && (
+            <>
+              <dt className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+                Your hit
+              </dt>
+              <dd className="text-sm text-[var(--color-fg)]">{matchup}</dd>
+            </>
+          )}
         </dl>
+
+        {sentiment === "hostile" && player && (
+          <button
+            onClick={onAttack}
+            className="tactile mt-4 inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-[var(--color-accent)] px-4 py-3 text-sm font-medium text-[var(--color-bg)] shadow-[0_8px_24px_-12px_rgba(217,104,70,0.5)]"
+          >
+            <Sword size={16} weight="fill" />
+            Attack
+          </button>
+        )}
       </div>
     </aside>
   );
+}
+
+function computeMatchup(player: Player | null, npc: Npc): string | null {
+  if (!player) return null;
+  if (!npc.interior) return "Out of reach";
+  const here = globalToLocal(player.gx, player.gy);
+  const dist = Math.max(
+    Math.abs(here.lx - npc.interior.lx),
+    Math.abs(here.ly - npc.interior.ly),
+  );
+  const weapon = pickWeaponForRange(player.weapons, dist);
+  const reach = weapon ? weaponReach(weapon) : player.stats.reach;
+  const damage = Math.max(
+    1,
+    player.stats.attack + weaponAttackBonus(weapon) - npc.combatDefense,
+  );
+  if (dist > reach) {
+    return `${dist} tiles away (need reach ${dist}+)`;
+  }
+  const weaponName = weapon ? WEAPONS[weapon.kind].label : "bare hands";
+  return `~${damage} dmg with ${weaponName}`;
 }
 
 function formatGoal(goal: Goal, npcs: Npc[]): string {

--- a/components/panels/NpcPanel.tsx
+++ b/components/panels/NpcPanel.tsx
@@ -135,7 +135,7 @@ function NpcPanelInner({
           )}
         </dl>
 
-        {sentiment === "hostile" && player && (
+        {sentiment !== "friendly" && player && (
           <button
             onClick={onAttack}
             className="tactile mt-4 inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-[var(--color-accent)] px-4 py-3 text-sm font-medium text-[var(--color-bg)] shadow-[0_8px_24px_-12px_rgba(217,104,70,0.5)]"

--- a/components/panels/RegionPanel.tsx
+++ b/components/panels/RegionPanel.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { Footprints, House, X } from "@phosphor-icons/react/dist/ssr";
+import { Footprints, Hammer, House, X } from "@phosphor-icons/react/dist/ssr";
 import { useGameStore, WALK_MAX_RADIUS } from "@/lib/state/game-store";
 import { biomeAt } from "@/lib/sim/biome";
 import { BIOMES } from "@/content/biomes";
 import { FACTIONS } from "@/content/factions";
-import { BIOME_RESOURCES, RESOURCES } from "@/content/resources";
+import {
+  BIOME_RESOURCES,
+  RESOURCES,
+  type ResourceKind,
+} from "@/content/resources";
 import { globalToLocal, regionCenterGlobal } from "@/lib/sim/biome-interior";
+import { WEAPONS, WEAPON_KINDS, type WeaponKind } from "@/content/weapons";
+import { affordable } from "@/lib/sim/weapons";
 
 export default function RegionPanel() {
   const region = useGameStore((s) => s.selectedRegion);
@@ -16,6 +22,7 @@ export default function RegionPanel() {
   const homePending = useGameStore((s) => s.homePending);
   const claimHome = useGameStore((s) => s.claimHome);
   const travelToRegion = useGameStore((s) => s.travelToRegion);
+  const craft = useGameStore((s) => s.craft);
 
   if (!region || !world) return null;
 
@@ -38,6 +45,9 @@ export default function RegionPanel() {
   const distance = player ? Math.abs(center.gx - player.gx) + Math.abs(center.gy - player.gy) : 0;
   const reachable = player && meta.passable && distance <= WALK_MAX_RADIUS && !isCurrentRegion;
   const showTravel = Boolean(player) && meta.passable && !isCurrentRegion && !world.gameOver;
+  const isHomeRegion =
+    Boolean(world.home) && world.home!.rx === region.rx && world.home!.ry === region.ry;
+  const showCrafting = isHomeRegion && isCurrentRegion && Boolean(player) && !world.gameOver;
 
   return (
     <aside
@@ -126,6 +136,66 @@ export default function RegionPanel() {
           </button>
         )}
 
+        {showCrafting && (
+          <section className="mt-4 border-t border-[var(--color-border)] pt-4">
+            <h3 className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+              Crafting
+            </h3>
+            <ul className="mt-3 flex flex-col gap-2">
+              {WEAPON_KINDS.map((kind) => {
+                const meta = WEAPONS[kind];
+                const can = affordable(world.inventory, kind);
+                const owned =
+                  player?.weapons.filter((w) => w.kind === kind).length ?? 0;
+                return (
+                  <li key={kind}>
+                    <button
+                      onClick={() => craft(kind)}
+                      disabled={!can}
+                      className="tactile flex w-full items-center gap-3 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-warm)] px-3 py-2 text-left disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      <Hammer
+                        size={16}
+                        weight={can ? "fill" : "regular"}
+                        className="shrink-0 text-[var(--color-accent)]"
+                      />
+                      <span className="flex-1">
+                        <span className="block text-sm font-medium text-[var(--color-fg)]">
+                          {meta.label}
+                          {owned > 0 && (
+                            <span className="ml-2 font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+                              {owned} held
+                            </span>
+                          )}
+                        </span>
+                        <span className="mt-0.5 flex items-center gap-2 font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+                          <span>+{meta.attack} atk</span>
+                          <span>reach {meta.reach}</span>
+                          {meta.ranged && <span>ranged</span>}
+                          <span>· uses {meta.durability}</span>
+                        </span>
+                        <span className="mt-1 flex flex-wrap gap-1.5">
+                          {(Object.entries(meta.recipe) as Array<[
+                            ResourceKind,
+                            number,
+                          ]>).map(([k, n]) => (
+                            <RecipePip
+                              key={k}
+                              kind={k}
+                              need={n}
+                              have={world.inventory[k] ?? 0}
+                            />
+                          ))}
+                        </span>
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        )}
+
         <dl className="mt-4 grid grid-cols-[auto_1fr] items-start gap-x-5 gap-y-3">
           <dt className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
             Here now
@@ -191,4 +261,29 @@ function factionHex(color: number): string {
 
 function factionLabel(id: string): string {
   return FACTIONS.find((f) => f.id === id)?.name ?? id;
+}
+
+function RecipePip({
+  kind,
+  need,
+  have,
+}: {
+  kind: ResourceKind;
+  need: number;
+  have: number;
+}) {
+  const ok = have >= need;
+  return (
+    <span
+      className="inline-flex items-center gap-1 font-mono text-[10px] tabular-nums"
+      style={{ color: ok ? "var(--color-fg)" : "var(--color-fg-muted)" }}
+    >
+      <span
+        aria-hidden
+        className="h-2 w-2 rounded-full border border-[var(--color-border-strong)]"
+        style={{ background: RESOURCES[kind].swatch }}
+      />
+      {have}/{need}
+    </span>
+  );
 }

--- a/components/panels/RegionPanel.tsx
+++ b/components/panels/RegionPanel.tsx
@@ -1,18 +1,12 @@
 "use client";
 
-import { Footprints, Hammer, House, X } from "@phosphor-icons/react/dist/ssr";
+import { Footprints, House, X } from "@phosphor-icons/react/dist/ssr";
 import { useGameStore, WALK_MAX_RADIUS } from "@/lib/state/game-store";
 import { biomeAt } from "@/lib/sim/biome";
 import { BIOMES } from "@/content/biomes";
 import { FACTIONS } from "@/content/factions";
-import {
-  BIOME_RESOURCES,
-  RESOURCES,
-  type ResourceKind,
-} from "@/content/resources";
+import { BIOME_RESOURCES, RESOURCES } from "@/content/resources";
 import { globalToLocal, regionCenterGlobal } from "@/lib/sim/biome-interior";
-import { WEAPONS, WEAPON_KINDS, type WeaponKind } from "@/content/weapons";
-import { affordable } from "@/lib/sim/weapons";
 
 export default function RegionPanel() {
   const region = useGameStore((s) => s.selectedRegion);
@@ -22,7 +16,9 @@ export default function RegionPanel() {
   const homePending = useGameStore((s) => s.homePending);
   const claimHome = useGameStore((s) => s.claimHome);
   const travelToRegion = useGameStore((s) => s.travelToRegion);
-  const craft = useGameStore((s) => s.craft);
+  const teleportToRegion = useGameStore((s) => s.teleportToRegion);
+  const debug = useGameStore((s) => s.debugMode);
+  const inspectBiome = useGameStore((s) => s.inspectBiome);
 
   if (!region || !world) return null;
 
@@ -45,9 +41,6 @@ export default function RegionPanel() {
   const distance = player ? Math.abs(center.gx - player.gx) + Math.abs(center.gy - player.gy) : 0;
   const reachable = player && meta.passable && distance <= WALK_MAX_RADIUS && !isCurrentRegion;
   const showTravel = Boolean(player) && meta.passable && !isCurrentRegion && !world.gameOver;
-  const isHomeRegion =
-    Boolean(world.home) && world.home!.rx === region.rx && world.home!.ry === region.ry;
-  const showCrafting = isHomeRegion && isCurrentRegion && Boolean(player) && !world.gameOver;
 
   return (
     <aside
@@ -136,64 +129,21 @@ export default function RegionPanel() {
           </button>
         )}
 
-        {showCrafting && (
-          <section className="mt-4 border-t border-[var(--color-border)] pt-4">
-            <h3 className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
-              Crafting
-            </h3>
-            <ul className="mt-3 flex flex-col gap-2">
-              {WEAPON_KINDS.map((kind) => {
-                const meta = WEAPONS[kind];
-                const can = affordable(world.inventory, kind);
-                const owned =
-                  player?.weapons.filter((w) => w.kind === kind).length ?? 0;
-                return (
-                  <li key={kind}>
-                    <button
-                      onClick={() => craft(kind)}
-                      disabled={!can}
-                      className="tactile flex w-full items-center gap-3 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-warm)] px-3 py-2 text-left disabled:cursor-not-allowed disabled:opacity-60"
-                    >
-                      <Hammer
-                        size={16}
-                        weight={can ? "fill" : "regular"}
-                        className="shrink-0 text-[var(--color-accent)]"
-                      />
-                      <span className="flex-1">
-                        <span className="block text-sm font-medium text-[var(--color-fg)]">
-                          {meta.label}
-                          {owned > 0 && (
-                            <span className="ml-2 font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
-                              {owned} held
-                            </span>
-                          )}
-                        </span>
-                        <span className="mt-0.5 flex items-center gap-2 font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
-                          <span>+{meta.attack} atk</span>
-                          <span>reach {meta.reach}</span>
-                          {meta.ranged && <span>ranged</span>}
-                          <span>· uses {meta.durability}</span>
-                        </span>
-                        <span className="mt-1 flex flex-wrap gap-1.5">
-                          {(Object.entries(meta.recipe) as Array<[
-                            ResourceKind,
-                            number,
-                          ]>).map(([k, n]) => (
-                            <RecipePip
-                              key={k}
-                              kind={k}
-                              need={n}
-                              have={world.inventory[k] ?? 0}
-                            />
-                          ))}
-                        </span>
-                      </span>
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          </section>
+        {debug && Boolean(player) && !isCurrentRegion && meta.passable && !world.gameOver && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              onClick={() => teleportToRegion(region.rx, region.ry)}
+              className="tactile inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface-warm)] px-3 py-1.5 font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg)]"
+            >
+              Teleport
+            </button>
+            <button
+              onClick={() => inspectBiome(region.rx, region.ry)}
+              className="tactile inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface-warm)] px-3 py-1.5 font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg)]"
+            >
+              Inspect biome
+            </button>
+          </div>
         )}
 
         <dl className="mt-4 grid grid-cols-[auto_1fr] items-start gap-x-5 gap-y-3">
@@ -261,29 +211,4 @@ function factionHex(color: number): string {
 
 function factionLabel(id: string): string {
   return FACTIONS.find((f) => f.id === id)?.name ?? id;
-}
-
-function RecipePip({
-  kind,
-  need,
-  have,
-}: {
-  kind: ResourceKind;
-  need: number;
-  have: number;
-}) {
-  const ok = have >= need;
-  return (
-    <span
-      className="inline-flex items-center gap-1 font-mono text-[10px] tabular-nums"
-      style={{ color: ok ? "var(--color-fg)" : "var(--color-fg-muted)" }}
-    >
-      <span
-        aria-hidden
-        className="h-2 w-2 rounded-full border border-[var(--color-border-strong)]"
-        style={{ background: RESOURCES[kind].swatch }}
-      />
-      {have}/{need}
-    </span>
-  );
 }

--- a/content/weapons.ts
+++ b/content/weapons.ts
@@ -1,0 +1,45 @@
+import type { ResourceKind } from "@/content/resources";
+
+export type WeaponKind = "stick" | "club" | "sling";
+
+export type WeaponMeta = {
+  label: string;
+  attack: number;
+  reach: number;
+  durability: number;
+  ranged: boolean;
+  recipe: Partial<Record<ResourceKind, number>>;
+  swatch: string;
+};
+
+export const WEAPONS: Record<WeaponKind, WeaponMeta> = {
+  stick: {
+    label: "Stick",
+    attack: 1,
+    reach: 1,
+    durability: 8,
+    ranged: false,
+    recipe: { wood: 1 },
+    swatch: "#8a6a4a",
+  },
+  club: {
+    label: "Club",
+    attack: 2,
+    reach: 1,
+    durability: 12,
+    ranged: false,
+    recipe: { wood: 2, stone: 1 },
+    swatch: "#7a5a3a",
+  },
+  sling: {
+    label: "Sling",
+    attack: 2,
+    reach: 4,
+    durability: 6,
+    ranged: true,
+    recipe: { reed: 2, stone: 1 },
+    swatch: "#a8b878",
+  },
+};
+
+export const WEAPON_KINDS: WeaponKind[] = ["stick", "club", "sling"];

--- a/lib/render/scenes/BiomeScene.ts
+++ b/lib/render/scenes/BiomeScene.ts
@@ -50,6 +50,7 @@ type VisitorView = {
   cy: number;
   targetCx: number;
   targetCy: number;
+  flashUntil: number;
 };
 
 type VisitorHit = { id: string; x: number; y: number; half: number };
@@ -63,6 +64,8 @@ export class BiomeScene extends Phaser.Scene {
   private selectionRing!: Phaser.GameObjects.Graphics;
   private visitorViews = new Map<string, VisitorView>();
   private visitorHits: VisitorHit[] = [];
+  private prevNpcHealth = new Map<string, number>();
+  private prevPlayerHealth = -1;
 
   private playerGx = 0;
   private playerGy = 0;
@@ -197,10 +200,80 @@ export class BiomeScene extends Phaser.Scene {
 
     this.drawTiles(world);
     this.drawResources(world);
+    this.drawLoot(world);
     this.drawRoute(player);
     this.drawPlayer();
     this.drawVisitors(world.npcs, world);
+    this.detectHits(world.npcs, world.player.health);
     this.drawSelection();
+  }
+
+  private drawLoot(world: { biomeInteriors: Record<string, BiomeInterior> }) {
+    const v = this.viewport();
+    const rxMin = Math.floor(v.gxMin / INTERIOR_W);
+    const rxMax = Math.floor(v.gxMax / INTERIOR_W);
+    const ryMin = Math.floor(v.gyMin / INTERIOR_H);
+    const ryMax = Math.floor(v.gyMax / INTERIOR_H);
+    for (let ry = ryMin; ry <= ryMax; ry++) {
+      for (let rx = rxMin; rx <= rxMax; rx++) {
+        const interior = world.biomeInteriors[regionKey(rx, ry)];
+        if (!interior) continue;
+        for (const pile of interior.loot) {
+          const cx = (rx * INTERIOR_W + pile.lx) * CELL + CELL / 2;
+          const cy = (ry * INTERIOR_H + pile.ly) * CELL + CELL / 2;
+          this.resourceLayer.fillStyle(COLORS.shadow, 0.18);
+          this.resourceLayer.fillEllipse(cx, cy + 6, 12, 3);
+          this.resourceLayer.fillStyle(0xc0a878, 0.95);
+          this.resourceLayer.fillRoundedRect(cx - 6, cy - 4, 12, 8, 2);
+          this.resourceLayer.lineStyle(1, COLORS.shadow, 0.5);
+          this.resourceLayer.strokeRoundedRect(cx - 6, cy - 4, 12, 8, 2);
+        }
+      }
+    }
+  }
+
+  private detectHits(npcs: Npc[], playerHealth: number) {
+    if (this.prevPlayerHealth >= 0 && playerHealth < this.prevPlayerHealth) {
+      const damage = this.prevPlayerHealth - playerHealth;
+      this.spawnDamageText(this.playerCx, this.playerCy - 10, damage);
+    }
+    this.prevPlayerHealth = playerHealth;
+
+    const seenIds = new Set<string>();
+    for (const npc of npcs) {
+      seenIds.add(npc.id);
+      const prev = this.prevNpcHealth.get(npc.id);
+      if (prev !== undefined && npc.combatHealth < prev) {
+        const damage = prev - npc.combatHealth;
+        const view = this.visitorViews.get(npc.id);
+        if (view) {
+          this.spawnDamageText(view.cx, view.cy - 10, damage);
+          view.flashUntil = this.time.now + 180;
+        }
+      }
+      this.prevNpcHealth.set(npc.id, npc.combatHealth);
+    }
+    for (const id of this.prevNpcHealth.keys()) {
+      if (!seenIds.has(id)) this.prevNpcHealth.delete(id);
+    }
+  }
+
+  private spawnDamageText(x: number, y: number, damage: number) {
+    const text = this.add.text(x, y, `-${damage}`, {
+      fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+      fontSize: "12px",
+      color: "#d96846",
+    });
+    text.setOrigin(0.5, 1);
+    text.setDepth(10);
+    this.tweens.add({
+      targets: text,
+      y: y - 18,
+      alpha: { from: 1, to: 0 },
+      duration: 600,
+      ease: "Cubic.easeOut",
+      onComplete: () => text.destroy(),
+    });
   }
 
   // Viewport in tile coords. Anchored on the camera's midpoint
@@ -500,26 +573,42 @@ export class BiomeScene extends Phaser.Scene {
 
     for (const npc of visitors) {
       seen.add(npc.id);
-      const slot = visitorSlot(npc.id, bucket, here.rx, here.ry, player.gx, player.gy);
-      const target = tileCenter(slot.gx, slot.gy);
+      let target: { x: number; y: number };
+      if (npc.interior) {
+        const gx = here.rx * INTERIOR_W + npc.interior.lx;
+        const gy = here.ry * INTERIOR_H + npc.interior.ly;
+        target = tileCenter(gx, gy);
+      } else {
+        const slot = visitorSlot(npc.id, bucket, here.rx, here.ry, player.gx, player.gy);
+        target = tileCenter(slot.gx, slot.gy);
+      }
 
       let view = this.visitorViews.get(npc.id);
       if (!view) {
         const body = this.add.graphics();
-        view = { body, cx: target.x, cy: target.y, targetCx: target.x, targetCy: target.y };
+        view = {
+          body,
+          cx: target.x,
+          cy: target.y,
+          targetCx: target.x,
+          targetCy: target.y,
+          flashUntil: 0,
+        };
         this.visitorViews.set(npc.id, view);
       }
       view.targetCx = target.x;
       view.targetCy = target.y;
-      view.cx += (view.targetCx - view.cx) * 0.08;
-      view.cy += (view.targetCy - view.cy) * 0.08;
+      view.cx += (view.targetCx - view.cx) * 0.18;
+      view.cy += (view.targetCy - view.cy) * 0.18;
 
       const faction = FACTIONS.find((f) => f.id === npc.factionId);
       const shape = faction?.shape ?? "diamond";
       view.body.clear();
       view.body.fillStyle(COLORS.shadow, 0.18);
       view.body.fillCircle(view.cx, view.cy + 2, NPC_SIZE / 2);
-      drawFactionShape(view.body, shape, npc.factionColor, view.cx, view.cy, NPC_SIZE, {
+      const flashing = this.time.now < view.flashUntil;
+      const fillColor = flashing ? 0xffffff : npc.factionColor;
+      drawFactionShape(view.body, shape, fillColor, view.cx, view.cy, NPC_SIZE, {
         stroke: 1.5,
         strokeColor: COLORS.outline,
       });

--- a/lib/render/scenes/BiomeScene.ts
+++ b/lib/render/scenes/BiomeScene.ts
@@ -51,6 +51,7 @@ type VisitorView = {
   targetCx: number;
   targetCy: number;
   flashUntil: number;
+  fading: boolean;
 };
 
 type VisitorHit = { id: string; x: number; y: number; half: number };
@@ -628,8 +629,14 @@ export class BiomeScene extends Phaser.Scene {
           targetCx: target.x,
           targetCy: target.y,
           flashUntil: 0,
+          fading: false,
         };
         this.visitorViews.set(npc.id, view);
+      } else if (view.fading) {
+        // NPC came back mid-fade. Cancel the fade and reset.
+        this.tweens.killTweensOf(view.body);
+        view.body.setAlpha(1);
+        view.fading = false;
       }
       view.targetCx = target.x;
       view.targetCy = target.y;
@@ -647,14 +654,22 @@ export class BiomeScene extends Phaser.Scene {
         stroke: 1.5,
         strokeColor: COLORS.outline,
       });
-      hits.push({ id: npc.id, x: view.cx, y: view.cy, half: NPC_SIZE / 2 + 6 });
+      hits.push({ id: npc.id, x: view.cx, y: view.cy, half: NPC_SIZE / 2 + 14 });
     }
 
     for (const [id, view] of this.visitorViews) {
-      if (!seen.has(id)) {
-        view.body.destroy();
-        this.visitorViews.delete(id);
-      }
+      if (seen.has(id) || view.fading) continue;
+      view.fading = true;
+      this.tweens.add({
+        targets: view.body,
+        alpha: { from: 1, to: 0 },
+        duration: 250,
+        ease: "Cubic.easeOut",
+        onComplete: () => {
+          view.body.destroy();
+          this.visitorViews.delete(id);
+        },
+      });
     }
     this.visitorHits = hits;
   }
@@ -773,10 +788,11 @@ export class BiomeScene extends Phaser.Scene {
       const world = this.cameras.main.getWorldPoint(pointer.x, pointer.y);
       const tappedVisitor = this.hitVisitorAt(world.x, world.y);
       if (tappedVisitor) {
-        useGameStore.getState().selectNpc(tappedVisitor);
+        useGameStore.getState().openNpcContextMenu(tappedVisitor, pointer.x, pointer.y);
       } else {
         const gx = Math.floor(world.x / CELL);
         const gy = Math.floor(world.y / CELL);
+        useGameStore.getState().closeNpcContextMenu();
         useGameStore.getState().walkPlayerTo(gx, gy);
       }
     }

--- a/lib/render/scenes/BiomeScene.ts
+++ b/lib/render/scenes/BiomeScene.ts
@@ -66,6 +66,7 @@ export class BiomeScene extends Phaser.Scene {
   private visitorHits: VisitorHit[] = [];
   private prevNpcHealth = new Map<string, number>();
   private prevPlayerHealth = -1;
+  private seenPickupIds = new Set<string>();
 
   private playerGx = 0;
   private playerGy = 0;
@@ -205,7 +206,41 @@ export class BiomeScene extends Phaser.Scene {
     this.drawPlayer();
     this.drawVisitors(world.npcs, world);
     this.detectHits(world.npcs, world.player.health);
+    this.spawnPickupTexts(world.recentPickups);
     this.drawSelection();
+  }
+
+  private spawnPickupTexts(pickups: { id: string; kind: ResourceKind; amount: number }[]) {
+    for (const p of pickups) {
+      if (this.seenPickupIds.has(p.id)) continue;
+      this.seenPickupIds.add(p.id);
+      const meta = RESOURCES[p.kind];
+      const text = this.add.text(
+        this.playerCx,
+        this.playerCy - 14,
+        `+${p.amount} ${meta.label}`,
+        {
+          fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+          fontSize: "12px",
+          color: meta.swatch,
+        },
+      );
+      text.setOrigin(0.5, 1);
+      text.setDepth(11);
+      this.tweens.add({
+        targets: text,
+        y: this.playerCy - 32,
+        alpha: { from: 1, to: 0 },
+        duration: 900,
+        ease: "Cubic.easeOut",
+        onComplete: () => text.destroy(),
+      });
+    }
+    // Garbage-collect ids that are no longer in the ring buffer.
+    if (this.seenPickupIds.size > 64) {
+      const live = new Set(pickups.map((p) => p.id));
+      for (const id of this.seenPickupIds) if (!live.has(id)) this.seenPickupIds.delete(id);
+    }
   }
 
   private drawLoot(world: { biomeInteriors: Record<string, BiomeInterior> }) {

--- a/lib/render/scenes/WorldScene.ts
+++ b/lib/render/scenes/WorldScene.ts
@@ -152,13 +152,21 @@ export class WorldScene extends Phaser.Scene {
     if (!world) return;
 
     if (world.ticks !== this.lastDrawnTick) {
-      this.renderNpcs(world.npcs);
-      if (useGameStore.getState().debugMode) {
+      const debug = useGameStore.getState().debugMode;
+      if (debug) {
+        this.renderNpcs(world.npcs);
         this.renderTelegraphs(world.npcs);
       } else {
+        this.npcLayer.clear();
         this.telegraphLayer.clear();
+        this.npcHits = [];
       }
-      this.renderFactionRings(world.regionControl, world.home);
+      const showFactions = useGameStore.getState().mapShowFactions;
+      if (showFactions) {
+        this.renderFactionRings(world.regionControl, world.home);
+      } else {
+        this.factionRingLayer.clear();
+      }
       this.lastDrawnTick = world.ticks;
     }
     this.renderHomeMarker();
@@ -196,6 +204,9 @@ export class WorldScene extends Phaser.Scene {
     home: { rx: number; ry: number } | null,
   ) {
     this.factionRingLayer.clear();
+    // Group regions by faction so each faction renders once. Skip the home
+    // region (it has its own marker) so the player's tile stays uncluttered.
+    const owned = new Map<string, Array<{ rx: number; ry: number }>>();
     for (const key of Object.keys(regionControl)) {
       const factionId = regionControl[key]!;
       const [sx, sy] = key.split(",");
@@ -203,16 +214,106 @@ export class WorldScene extends Phaser.Scene {
       const ry = Number(sy);
       if (!Number.isFinite(rx) || !Number.isFinite(ry)) continue;
       if (home && home.rx === rx && home.ry === ry) continue;
+      const arr = owned.get(factionId) ?? [];
+      arr.push({ rx, ry });
+      owned.set(factionId, arr);
+    }
+    for (const [factionId, regions] of owned) {
       const faction = FACTIONS.find((f) => f.id === factionId);
       if (!faction) continue;
-      const px = rx * REGION + PADDING;
-      const py = ry * REGION + PADDING;
-      // Soft tinted fill so zones read as territory, not as a thin border
-      // that competes with tile edges and the selection ring.
-      this.factionRingLayer.fillStyle(faction.color, 0.28);
-      this.factionRingLayer.fillRoundedRect(px, py, INNER, INNER, RADIUS);
-      this.factionRingLayer.lineStyle(2.5, faction.color, 0.85);
-      this.factionRingLayer.strokeRoundedRect(px, py, INNER, INNER, RADIUS);
+      const occupied = new Set(regions.map((r) => `${r.rx},${r.ry}`));
+      const isOwn = (rx: number, ry: number) => occupied.has(`${rx},${ry}`);
+
+      // Soft underlay so the hatch reads against very light biome tiles.
+      this.factionRingLayer.fillStyle(faction.color, 0.10);
+      for (const r of regions) {
+        const px = r.rx * REGION;
+        const py = r.ry * REGION;
+        this.factionRingLayer.fillRect(px, py, REGION, REGION);
+      }
+
+      // Cross-hatch fill, anchored to a global lattice so adjacent same-
+      // faction regions share continuous lines (no seams at region edges).
+      this.factionRingLayer.lineStyle(1, faction.color, 0.55);
+      const hatchStep = 8;
+      for (const r of regions) {
+        this.drawHatchInRegion(r.rx, r.ry, hatchStep, +1);
+        this.drawHatchInRegion(r.rx, r.ry, hatchStep, -1);
+      }
+
+      // Perimeter: only stroke an edge when the neighbouring region isn't
+      // the same faction. Adjacent same-faction regions visually merge.
+      this.factionRingLayer.lineStyle(2, faction.color, 0.9);
+      for (const r of regions) {
+        const px = r.rx * REGION;
+        const py = r.ry * REGION;
+        if (!isOwn(r.rx, r.ry - 1)) {
+          this.factionRingLayer.beginPath();
+          this.factionRingLayer.moveTo(px, py);
+          this.factionRingLayer.lineTo(px + REGION, py);
+          this.factionRingLayer.strokePath();
+        }
+        if (!isOwn(r.rx + 1, r.ry)) {
+          this.factionRingLayer.beginPath();
+          this.factionRingLayer.moveTo(px + REGION, py);
+          this.factionRingLayer.lineTo(px + REGION, py + REGION);
+          this.factionRingLayer.strokePath();
+        }
+        if (!isOwn(r.rx, r.ry + 1)) {
+          this.factionRingLayer.beginPath();
+          this.factionRingLayer.moveTo(px, py + REGION);
+          this.factionRingLayer.lineTo(px + REGION, py + REGION);
+          this.factionRingLayer.strokePath();
+        }
+        if (!isOwn(r.rx - 1, r.ry)) {
+          this.factionRingLayer.beginPath();
+          this.factionRingLayer.moveTo(px, py);
+          this.factionRingLayer.lineTo(px, py + REGION);
+          this.factionRingLayer.strokePath();
+        }
+      }
+    }
+  }
+
+  // Draw clipped diagonal lines y = slope*x + c within one region rect.
+  // c is a multiple of step so adjacent regions in the same faction share
+  // the same lattice and the lines look continuous across the seam.
+  private drawHatchInRegion(rx: number, ry: number, step: number, slope: 1 | -1) {
+    const x0 = rx * REGION;
+    const y0 = ry * REGION;
+    const x1 = x0 + REGION;
+    const y1 = y0 + REGION;
+    // y = slope*x + c => c = y - slope*x. Range over rect corners:
+    const cs = [
+      y0 - slope * x0,
+      y0 - slope * x1,
+      y1 - slope * x0,
+      y1 - slope * x1,
+    ];
+    const cMin = Math.ceil(Math.min(...cs) / step) * step;
+    const cMax = Math.floor(Math.max(...cs) / step) * step;
+    for (let c = cMin; c <= cMax; c += step) {
+      // Find intersection with rect edges.
+      const ys: Array<{ x: number; y: number }> = [];
+      // x = x0
+      const yAtX0 = slope * x0 + c;
+      if (yAtX0 >= y0 && yAtX0 <= y1) ys.push({ x: x0, y: yAtX0 });
+      // x = x1
+      const yAtX1 = slope * x1 + c;
+      if (yAtX1 >= y0 && yAtX1 <= y1) ys.push({ x: x1, y: yAtX1 });
+      // y = y0
+      const xAtY0 = (y0 - c) / slope;
+      if (xAtY0 > x0 && xAtY0 < x1) ys.push({ x: xAtY0, y: y0 });
+      // y = y1
+      const xAtY1 = (y1 - c) / slope;
+      if (xAtY1 > x0 && xAtY1 < x1) ys.push({ x: xAtY1, y: y1 });
+      if (ys.length < 2) continue;
+      const a = ys[0]!;
+      const b = ys[1]!;
+      this.factionRingLayer.beginPath();
+      this.factionRingLayer.moveTo(a.x, a.y);
+      this.factionRingLayer.lineTo(b.x, b.y);
+      this.factionRingLayer.strokePath();
     }
   }
 

--- a/lib/render/scenes/WorldScene.ts
+++ b/lib/render/scenes/WorldScene.ts
@@ -153,7 +153,11 @@ export class WorldScene extends Phaser.Scene {
 
     if (world.ticks !== this.lastDrawnTick) {
       this.renderNpcs(world.npcs);
-      this.renderTelegraphs(world.npcs);
+      if (useGameStore.getState().debugMode) {
+        this.renderTelegraphs(world.npcs);
+      } else {
+        this.telegraphLayer.clear();
+      }
       this.renderFactionRings(world.regionControl, world.home);
       this.lastDrawnTick = world.ticks;
     }

--- a/lib/sim/biome-interior.ts
+++ b/lib/sim/biome-interior.ts
@@ -22,6 +22,10 @@ export type LootPile = {
   lx: number;
   ly: number;
   items: Partial<Record<ResourceKind, number>>;
+  weapons?: import("@/lib/sim/weapons").WeaponInstance[];
+  // Optional flag: this pile was dropped by the player on death. Lets the
+  // render layer show it differently and the encounter feed reference it.
+  fromDeath?: boolean;
 };
 
 export type BiomeInterior = {

--- a/lib/sim/biome-interior.ts
+++ b/lib/sim/biome-interior.ts
@@ -17,12 +17,20 @@ export type InteriorResource = {
   kind: ResourceKind;
 };
 
+export type LootPile = {
+  id: string;
+  lx: number;
+  ly: number;
+  items: Partial<Record<ResourceKind, number>>;
+};
+
 export type BiomeInterior = {
   rx: number;
   ry: number;
   biome: Biome;
   obstacles: boolean[];
   resources: InteriorResource[];
+  loot: LootPile[];
 };
 
 export function regionKey(rx: number, ry: number): string {
@@ -68,12 +76,13 @@ export function generateInterior(worldSeed: number, rx: number, ry: number): Bio
       biome,
       obstacles: new Array<boolean>(INTERIOR_W * INTERIOR_H).fill(true),
       resources: [],
+      loot: [],
     };
   }
 
   const obstacles = scatterObstacles(rng);
   const resources = scatterResources(rng, biome, obstacles);
-  return { rx, ry, biome, obstacles, resources };
+  return { rx, ry, biome, obstacles, resources, loot: [] };
 }
 
 export function isLocalObstacle(interior: BiomeInterior, lx: number, ly: number): boolean {
@@ -96,6 +105,48 @@ export function removeResource(
   const next = interior.resources.filter((r) => r.id !== resourceId);
   if (next.length === interior.resources.length) return interior;
   return { ...interior, resources: next };
+}
+
+export function lootAtLocal(
+  interior: BiomeInterior,
+  lx: number,
+  ly: number,
+): LootPile | null {
+  return interior.loot.find((l) => l.lx === lx && l.ly === ly) ?? null;
+}
+
+export function addLoot(interior: BiomeInterior, pile: LootPile): BiomeInterior {
+  return { ...interior, loot: [...interior.loot, pile] };
+}
+
+export function removeLoot(interior: BiomeInterior, lootId: string): BiomeInterior {
+  const next = interior.loot.filter((l) => l.id !== lootId);
+  if (next.length === interior.loot.length) return interior;
+  return { ...interior, loot: next };
+}
+
+// Find a passable interior tile near (cx, cy) that isn't occupied by another
+// NPC. Used for spawning NPC interior slots and loot piles.
+export function findPassableTile(
+  interior: BiomeInterior,
+  cx: number,
+  cy: number,
+  isOccupied: (lx: number, ly: number) => boolean,
+): { lx: number; ly: number } | null {
+  for (let r = 0; r <= Math.max(INTERIOR_W, INTERIOR_H); r++) {
+    for (let dy = -r; dy <= r; dy++) {
+      for (let dx = -r; dx <= r; dx++) {
+        if (Math.abs(dx) !== r && Math.abs(dy) !== r) continue;
+        const lx = cx + dx;
+        const ly = cy + dy;
+        if (lx < 0 || ly < 0 || lx >= INTERIOR_W || ly >= INTERIOR_H) continue;
+        if (isLocalObstacle(interior, lx, ly)) continue;
+        if (isOccupied(lx, ly)) continue;
+        return { lx, ly };
+      }
+    }
+  }
+  return null;
 }
 
 function mixSeed(worldSeed: number, rx: number, ry: number): number {

--- a/lib/sim/combat.ts
+++ b/lib/sim/combat.ts
@@ -243,7 +243,7 @@ function runInteriorCombat(
           ...n.interior,
           lx: stepped.next.lx,
           ly: stepped.next.ly,
-          tileIntent: null,
+          tileIntent: stepped.tileIntent,
           stepCooldown: rng.int(TILE_STEP_COOLDOWN_MIN, TILE_STEP_COOLDOWN_MAX + 1),
         },
       };
@@ -252,6 +252,7 @@ function runInteriorCombat(
         ...n,
         interior: {
           ...n.interior,
+          tileIntent: stepped.tileIntent,
           stepCooldown: rng.int(TILE_STEP_COOLDOWN_MIN, TILE_STEP_COOLDOWN_MAX + 1),
         },
       };
@@ -263,6 +264,7 @@ function runInteriorCombat(
 
 type StepResult = {
   next: { lx: number; ly: number } | null;
+  tileIntent: { lx: number; ly: number } | null;
   transitioned: { rx: number; ry: number } | null;
 };
 
@@ -279,21 +281,9 @@ function stepTowardTarget(
   rng: Rng,
 ): StepResult {
   const interiorPos = npc.interior!;
-  // Pick the tile-level target based on goal + hostility.
-  let target = pickTileTarget(npc, npcs, inHere, selfIdx, here, mapW, mapH, res);
-  if (!target) {
-    // Random wander to avoid frozen NPCs.
-    target = randomNearby(interiorPos.lx, interiorPos.ly, rng);
-  }
 
-  // If we're already at the target tile and the goal wants this region, idle.
-  if (target.lx === interiorPos.lx && target.ly === interiorPos.ly) {
-    return { next: null, transitioned: null };
-  }
-
-  // BFS over interior obstacles, treating other NPCs as blocked.
+  // Build occupancy grid for BFS + random-walk obstacle checks.
   const occupied: boolean[] = interior.obstacles.slice();
-  // Mark player tile as blocked so NPCs don't try to occupy it.
   occupied[here.ly * INTERIOR_W + here.lx] = true;
   for (const j of inHere) {
     if (j === selfIdx) continue;
@@ -302,37 +292,55 @@ function stepTowardTarget(
     occupied[m.interior.ly * INTERIOR_W + m.interior.lx] = true;
   }
 
-  // Edge transition: if target is at an interior edge and the NPC stands on
-  // the same edge tile, advance to the neighbouring region.
+  const dynamicTarget = pickDynamicTileTarget(npc, npcs, inHere, selfIdx, here, res);
+
+  // Decide effective target: dynamic (player/enemy/edge) overrides any cached
+  // wander; otherwise reuse cached tileIntent until we arrive, then reroll.
+  let target: { lx: number; ly: number } | null = dynamicTarget;
+  if (!target) {
+    const cached = interiorPos.tileIntent;
+    if (
+      cached &&
+      !(cached.lx === interiorPos.lx && cached.ly === interiorPos.ly) &&
+      !occupied[cached.ly * INTERIOR_W + cached.lx]
+    ) {
+      target = cached;
+    } else {
+      target = pickWanderTarget(interiorPos.lx, interiorPos.ly, occupied, rng);
+    }
+  }
+
+  if (!target) {
+    return { next: null, tileIntent: null, transitioned: null };
+  }
+
+  // Edge-tile arrival: transition out of the region.
   if (
     target.lx === interiorPos.lx &&
     target.ly === interiorPos.ly &&
-    isEdgeTile(target.lx, target.ly)
+    isEdgeTile(target.lx, target.ly) &&
+    wantsToLeaveRegion(npc, here)
   ) {
     const transit = neighborRegionForEdge(here.rx, here.ry, target.lx, target.ly, mapW, mapH);
-    if (transit) return { next: null, transitioned: transit };
+    if (transit) return { next: null, tileIntent: null, transitioned: transit };
+  }
+
+  if (target.lx === interiorPos.lx && target.ly === interiorPos.ly) {
+    // Already there but didn't transition — clear cache so next tick rerolls.
+    return { next: null, tileIntent: null, transitioned: null };
   }
 
   const path = bfs(occupied, INTERIOR_W, INTERIOR_H, interiorPos.lx, interiorPos.ly, target.lx, target.ly);
   if (!path || path.length === 0) {
-    // Try a random nearby walk if direct path is blocked.
-    const wander = randomNearby(interiorPos.lx, interiorPos.ly, rng);
-    if (wander.lx === interiorPos.lx && wander.ly === interiorPos.ly) {
-      return { next: null, transitioned: null };
-    }
-    if (
-      wander.lx >= 0 &&
-      wander.lx < INTERIOR_W &&
-      wander.ly >= 0 &&
-      wander.ly < INTERIOR_H &&
-      !occupied[wander.ly * INTERIOR_W + wander.lx]
-    ) {
-      return { next: { lx: wander.lx, ly: wander.ly }, transitioned: null };
-    }
-    return { next: null, transitioned: null };
+    // Direct path blocked: take any free neighbour to keep moving and drop
+    // the cached intent so next tick rerolls.
+    const free = freeNeighbor(interiorPos.lx, interiorPos.ly, occupied, rng);
+    if (free) return { next: free, tileIntent: null, transitioned: null };
+    return { next: null, tileIntent: null, transitioned: null };
   }
   const step = path[0]!;
-  // If we arrived at an edge tile and the goal wants to leave, transition.
+  // If the chosen step is the goal tile and it's an edge tile we wanted to
+  // leave through, transit immediately.
   if (
     step.px === target.lx &&
     step.py === target.ly &&
@@ -340,19 +348,67 @@ function stepTowardTarget(
     wantsToLeaveRegion(npc, here)
   ) {
     const transit = neighborRegionForEdge(here.rx, here.ry, step.px, step.py, mapW, mapH);
-    if (transit) return { next: null, transitioned: transit };
+    if (transit) return { next: null, tileIntent: null, transitioned: transit };
   }
-  return { next: { lx: step.px, ly: step.py }, transitioned: null };
+  return {
+    next: { lx: step.px, ly: step.py },
+    tileIntent: { lx: target.lx, ly: target.ly },
+    transitioned: null,
+  };
 }
 
-function pickTileTarget(
+function freeNeighbor(
+  lx: number,
+  ly: number,
+  occupied: boolean[],
+  rng: Rng,
+): { lx: number; ly: number } | null {
+  const choices: Array<[number, number]> = [];
+  for (const [dx, dy] of [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+  ] as const) {
+    const nx = lx + dx;
+    const ny = ly + dy;
+    if (nx < 0 || ny < 0 || nx >= INTERIOR_W || ny >= INTERIOR_H) continue;
+    if (occupied[ny * INTERIOR_W + nx]) continue;
+    choices.push([nx, ny]);
+  }
+  if (choices.length === 0) return null;
+  const pick = choices[rng.int(0, choices.length)]!;
+  return { lx: pick[0], ly: pick[1] };
+}
+
+function pickWanderTarget(
+  lx: number,
+  ly: number,
+  occupied: boolean[],
+  rng: Rng,
+): { lx: number; ly: number } | null {
+  for (let attempt = 0; attempt < 12; attempt++) {
+    const dx = rng.int(-6, 7);
+    const dy = rng.int(-6, 7);
+    const nx = lx + dx;
+    const ny = ly + dy;
+    if (nx < 0 || ny < 0 || nx >= INTERIOR_W || ny >= INTERIOR_H) continue;
+    if (occupied[ny * INTERIOR_W + nx]) continue;
+    if (nx === lx && ny === ly) continue;
+    return { lx: nx, ly: ny };
+  }
+  return freeNeighbor(lx, ly, occupied, rng);
+}
+
+// Returns a target the NPC *must* reach this tick (player tile when hostile,
+// nearest enemy NPC tile, region-edge when leaving). Otherwise returns null
+// and we fall through to a cached wander tile.
+function pickDynamicTileTarget(
   npc: Npc,
   npcs: Npc[],
   inHere: number[],
   selfIdx: number,
   here: { rx: number; ry: number; lx: number; ly: number },
-  mapW: number,
-  mapH: number,
   res: CombatResult,
 ): { lx: number; ly: number } | null {
   const playerHostile = (res.playerReputation[npc.factionId] ?? 0) < 0;
@@ -360,7 +416,6 @@ function pickTileTarget(
     return { lx: here.lx, ly: here.ly };
   }
 
-  // Hostile NPC of another faction in this interior?
   for (const j of inHere) {
     if (j === selfIdx) continue;
     const m = npcs[j]!;
@@ -378,8 +433,6 @@ function pickTileTarget(
     }
   }
 
-  // Goal-directed: if region-level goal points elsewhere, head to the matching
-  // edge tile so the NPC can transition out next tick.
   const regionTarget = goalTarget(npc.goal, npc, npcs);
   if (regionTarget && (regionTarget.rx !== here.rx || regionTarget.ry !== here.ry)) {
     const dx = regionTarget.rx - here.rx;
@@ -391,12 +444,7 @@ function pickTileTarget(
       return { lx: clamp(npc.interior!.lx, 0, INTERIOR_W - 1), ly: dy > 0 ? INTERIOR_H - 1 : 0 };
     }
   }
-
-  // Default wander: pick the interior centre as a soft anchor to avoid
-  // clustering at the spawn edge.
-  const cx = Math.floor(INTERIOR_W / 2);
-  const cy = Math.floor(INTERIOR_H / 2);
-  return { lx: cx, ly: cy };
+  return null;
 }
 
 function wantsToLeaveRegion(
@@ -429,17 +477,6 @@ function neighborRegionForEdge(
   else return null;
   if (!isPassable(nrx, nry, mapW, mapH)) return null;
   return { rx: nrx, ry: nry };
-}
-
-function randomNearby(lx: number, ly: number, rng: Rng): { lx: number; ly: number } {
-  const choices: Array<[number, number]> = [
-    [lx + 1, ly],
-    [lx - 1, ly],
-    [lx, ly + 1],
-    [lx, ly - 1],
-  ];
-  const pick = choices[rng.int(0, choices.length)]!;
-  return { lx: pick[0], ly: pick[1] };
 }
 
 function clamp(v: number, lo: number, hi: number): number {

--- a/lib/sim/combat.ts
+++ b/lib/sim/combat.ts
@@ -1,0 +1,806 @@
+import type { Rng } from "@/lib/sim/rng";
+import type { Npc, NpcInterior } from "@/lib/sim/npc";
+import type { Player } from "@/lib/sim/player";
+import type { FactionState } from "@/lib/sim/faction";
+import {
+  isFactionHostile,
+  losePlayerRep,
+  nudgePower,
+  nudgeRelation,
+} from "@/lib/sim/faction";
+import {
+  addLoot,
+  globalToLocal,
+  regionKey,
+  findPassableTile,
+  INTERIOR_W,
+  INTERIOR_H,
+  type BiomeInterior,
+  type LootPile,
+} from "@/lib/sim/biome-interior";
+import { isPassable } from "@/lib/sim/biome";
+import {
+  consumeUse,
+  pickWeaponForRange,
+  weaponAttackBonus,
+  weaponReach,
+  type WeaponInstance,
+} from "@/lib/sim/weapons";
+import { bfs } from "@/lib/sim/path";
+import { goalTarget } from "@/lib/sim/goal";
+import type { ResourceKind } from "@/content/resources";
+
+export const COMBAT_COOLDOWN_TICKS = 4;
+export const TILE_STEP_COOLDOWN_MIN = 1;
+export const TILE_STEP_COOLDOWN_MAX = 4;
+export const REGION_PAIRS_PER_TICK = 4;
+export const MAX_REGION_HITS_PER_TICK = 6;
+
+export type CombatHit = {
+  defenderKind: "player" | "npc";
+  defenderId?: string;
+  attackerName: string;
+  damage: number;
+  lx?: number;
+  ly?: number;
+};
+
+export type CombatDeath = {
+  npcId: string;
+  factionId: string;
+  name: string;
+  killerKind: "player" | "npc";
+  killerId?: string;
+  killerName?: string;
+};
+
+export type CombatResult = {
+  npcs: Npc[];
+  player: Player | null;
+  interiors: Record<string, BiomeInterior>;
+  factions: FactionState[];
+  factionRelations: Record<string, number>;
+  playerReputation: Record<string, number>;
+  hits: CombatHit[];
+  deaths: CombatDeath[];
+  playerKilledBy?: { npcId: string; name: string; factionId: string };
+};
+
+export type CombatInput = {
+  npcs: Npc[];
+  player: Player | null;
+  interiors: Record<string, BiomeInterior>;
+  factions: FactionState[];
+  factionRelations: Record<string, number>;
+  playerReputation: Record<string, number>;
+  mapW: number;
+  mapH: number;
+};
+
+export function tickCombat(input: CombatInput, rng: Rng): CombatResult {
+  const result: CombatResult = {
+    npcs: input.npcs,
+    player: input.player,
+    interiors: input.interiors,
+    factions: input.factions,
+    factionRelations: input.factionRelations,
+    playerReputation: input.playerReputation,
+    hits: [],
+    deaths: [],
+  };
+
+  // Always run interior combat first (when player exists), then region-level
+  // abstract combat. This keeps the player's neighbourhood crisp and lets
+  // off-screen kills affect faction power before encounter detection.
+  if (result.player) {
+    runInteriorCombat(result, rng, input.mapW, input.mapH);
+  }
+  runRegionCombat(result, rng, input.mapW, input.mapH);
+  return result;
+}
+
+function runInteriorCombat(
+  res: CombatResult,
+  rng: Rng,
+  mapW: number,
+  mapH: number,
+): void {
+  const player = res.player;
+  if (!player) return;
+  const here = globalToLocal(player.gx, player.gy);
+  const interior = res.interiors[regionKey(here.rx, here.ry)];
+  if (!interior) return;
+
+  const npcs = res.npcs.slice();
+
+  // Clear stale interior state on any NPC outside the player's region. They
+  // keep their region-level rx/ry but the tile slot belongs to a region we
+  // are no longer rendering, so it's nonsense state.
+  for (let i = 0; i < npcs.length; i++) {
+    const n = npcs[i]!;
+    if (n.interior && (n.rx !== here.rx || n.ry !== here.ry)) {
+      npcs[i] = { ...n, interior: null, combatIntent: null };
+    }
+  }
+
+  // Index NPCs in player's region for occupancy + collision.
+  const inHere: number[] = [];
+  for (let i = 0; i < npcs.length; i++) {
+    const n = npcs[i]!;
+    if (n.rx === here.rx && n.ry === here.ry) inHere.push(i);
+  }
+
+  // Materialize interior slots for fresh entrants.
+  for (const idx of inHere) {
+    const n = npcs[idx]!;
+    if (n.interior) continue;
+    const occupied = (lx: number, ly: number) => {
+      if (lx === here.lx && ly === here.ly) return true;
+      for (const j of inHere) {
+        const m = npcs[j]!;
+        if (m.id === n.id) continue;
+        if (m.interior && m.interior.lx === lx && m.interior.ly === ly) return true;
+      }
+      return false;
+    };
+    const seed = rng.int(0, INTERIOR_W * INTERIOR_H);
+    const cx = seed % INTERIOR_W;
+    const cy = (seed - cx) / INTERIOR_W;
+    const slot = findPassableTile(interior, cx, cy, occupied);
+    if (!slot) continue;
+    npcs[idx] = {
+      ...n,
+      interior: {
+        lx: slot.lx,
+        ly: slot.ly,
+        tileIntent: null,
+        stepCooldown: rng.int(TILE_STEP_COOLDOWN_MIN, TILE_STEP_COOLDOWN_MAX + 1),
+        lastHitTick: -999,
+      },
+    };
+  }
+
+  // Process attacks before movement so cooldowns gate movement coherently.
+  // Player attack pending action: handled in player-tick. Here we resolve
+  // NPC-vs-player and NPC-vs-NPC.
+  for (const idx of inHere) {
+    const n = npcs[idx]!;
+    const interior = n.interior;
+    if (!interior) continue;
+    if (n.combatCooldown > 0) {
+      npcs[idx] = { ...n, combatCooldown: n.combatCooldown - 1 };
+      continue;
+    }
+
+    // Look for hostile target: player (if hostile to player) or another NPC.
+    const playerHostile = (res.playerReputation[n.factionId] ?? 0) < 0;
+    const playerDist = chebyshev(interior.lx, interior.ly, here.lx, here.ly);
+    if (playerHostile && playerDist <= n.combatReach && res.player) {
+      const hit = attackPlayer(res, n, rng);
+      npcs[idx] = hit.npc;
+      continue;
+    }
+
+    // Hostile NPC pair?
+    let bestEnemy: { idx: number; dist: number } | null = null;
+    for (const j of inHere) {
+      if (j === idx) continue;
+      const m = npcs[j]!;
+      if (!m.interior) continue;
+      if (m.combatHealth <= 0) continue;
+      if (
+        !isFactionHostile(
+          res.factionRelations,
+          n.values,
+          m.values,
+          n.factionId,
+          m.factionId,
+        )
+      ) {
+        continue;
+      }
+      const d = chebyshev(interior.lx, interior.ly, m.interior.lx, m.interior.ly);
+      if (d > n.combatReach) continue;
+      if (!bestEnemy || d < bestEnemy.dist) bestEnemy = { idx: j, dist: d };
+    }
+    if (bestEnemy) {
+      const target = npcs[bestEnemy.idx]!;
+      const r = attackNpcByNpc(res, n, target, rng);
+      npcs[idx] = r.attacker;
+      npcs[bestEnemy.idx] = r.defender;
+      continue;
+    }
+  }
+
+  // Movement: each NPC steps toward a tile-level target. The target depends
+  // on goal kind and proximity to the player or hostiles.
+  for (const idx of inHere) {
+    const n = npcs[idx]!;
+    if (!n.interior) continue;
+    if (n.combatHealth <= 0) continue;
+    if (n.interior.stepCooldown > 0) {
+      npcs[idx] = {
+        ...n,
+        interior: { ...n.interior, stepCooldown: n.interior.stepCooldown - 1 },
+      };
+      continue;
+    }
+    const stepped = stepTowardTarget(n, npcs, inHere, idx, here, interior, mapW, mapH, res, rng);
+    if (stepped.transitioned) {
+      // NPC left the player's region; clear interior, advance rx/ry.
+      npcs[idx] = {
+        ...n,
+        rx: stepped.transitioned.rx,
+        ry: stepped.transitioned.ry,
+        intent: null,
+        interior: null,
+        moveCooldown: rng.int(8, 16),
+      };
+    } else if (stepped.next) {
+      npcs[idx] = {
+        ...n,
+        interior: {
+          ...n.interior,
+          lx: stepped.next.lx,
+          ly: stepped.next.ly,
+          tileIntent: null,
+          stepCooldown: rng.int(TILE_STEP_COOLDOWN_MIN, TILE_STEP_COOLDOWN_MAX + 1),
+        },
+      };
+    } else {
+      npcs[idx] = {
+        ...n,
+        interior: {
+          ...n.interior,
+          stepCooldown: rng.int(TILE_STEP_COOLDOWN_MIN, TILE_STEP_COOLDOWN_MAX + 1),
+        },
+      };
+    }
+  }
+
+  res.npcs = npcs;
+}
+
+type StepResult = {
+  next: { lx: number; ly: number } | null;
+  transitioned: { rx: number; ry: number } | null;
+};
+
+function stepTowardTarget(
+  npc: Npc,
+  npcs: Npc[],
+  inHere: number[],
+  selfIdx: number,
+  here: { rx: number; ry: number; lx: number; ly: number },
+  interior: BiomeInterior,
+  mapW: number,
+  mapH: number,
+  res: CombatResult,
+  rng: Rng,
+): StepResult {
+  const interiorPos = npc.interior!;
+  // Pick the tile-level target based on goal + hostility.
+  let target = pickTileTarget(npc, npcs, inHere, selfIdx, here, mapW, mapH, res);
+  if (!target) {
+    // Random wander to avoid frozen NPCs.
+    target = randomNearby(interiorPos.lx, interiorPos.ly, rng);
+  }
+
+  // If we're already at the target tile and the goal wants this region, idle.
+  if (target.lx === interiorPos.lx && target.ly === interiorPos.ly) {
+    return { next: null, transitioned: null };
+  }
+
+  // BFS over interior obstacles, treating other NPCs as blocked.
+  const occupied: boolean[] = interior.obstacles.slice();
+  // Mark player tile as blocked so NPCs don't try to occupy it.
+  occupied[here.ly * INTERIOR_W + here.lx] = true;
+  for (const j of inHere) {
+    if (j === selfIdx) continue;
+    const m = npcs[j]!;
+    if (!m.interior) continue;
+    occupied[m.interior.ly * INTERIOR_W + m.interior.lx] = true;
+  }
+
+  // Edge transition: if target is at an interior edge and the NPC stands on
+  // the same edge tile, advance to the neighbouring region.
+  if (
+    target.lx === interiorPos.lx &&
+    target.ly === interiorPos.ly &&
+    isEdgeTile(target.lx, target.ly)
+  ) {
+    const transit = neighborRegionForEdge(here.rx, here.ry, target.lx, target.ly, mapW, mapH);
+    if (transit) return { next: null, transitioned: transit };
+  }
+
+  const path = bfs(occupied, INTERIOR_W, INTERIOR_H, interiorPos.lx, interiorPos.ly, target.lx, target.ly);
+  if (!path || path.length === 0) {
+    // Try a random nearby walk if direct path is blocked.
+    const wander = randomNearby(interiorPos.lx, interiorPos.ly, rng);
+    if (wander.lx === interiorPos.lx && wander.ly === interiorPos.ly) {
+      return { next: null, transitioned: null };
+    }
+    if (
+      wander.lx >= 0 &&
+      wander.lx < INTERIOR_W &&
+      wander.ly >= 0 &&
+      wander.ly < INTERIOR_H &&
+      !occupied[wander.ly * INTERIOR_W + wander.lx]
+    ) {
+      return { next: { lx: wander.lx, ly: wander.ly }, transitioned: null };
+    }
+    return { next: null, transitioned: null };
+  }
+  const step = path[0]!;
+  // If we arrived at an edge tile and the goal wants to leave, transition.
+  if (
+    step.px === target.lx &&
+    step.py === target.ly &&
+    isEdgeTile(step.px, step.py) &&
+    wantsToLeaveRegion(npc, here)
+  ) {
+    const transit = neighborRegionForEdge(here.rx, here.ry, step.px, step.py, mapW, mapH);
+    if (transit) return { next: null, transitioned: transit };
+  }
+  return { next: { lx: step.px, ly: step.py }, transitioned: null };
+}
+
+function pickTileTarget(
+  npc: Npc,
+  npcs: Npc[],
+  inHere: number[],
+  selfIdx: number,
+  here: { rx: number; ry: number; lx: number; ly: number },
+  mapW: number,
+  mapH: number,
+  res: CombatResult,
+): { lx: number; ly: number } | null {
+  const playerHostile = (res.playerReputation[npc.factionId] ?? 0) < 0;
+  if (playerHostile && res.player) {
+    return { lx: here.lx, ly: here.ly };
+  }
+
+  // Hostile NPC of another faction in this interior?
+  for (const j of inHere) {
+    if (j === selfIdx) continue;
+    const m = npcs[j]!;
+    if (!m.interior || m.combatHealth <= 0) continue;
+    if (
+      isFactionHostile(
+        res.factionRelations,
+        npc.values,
+        m.values,
+        npc.factionId,
+        m.factionId,
+      )
+    ) {
+      return { lx: m.interior.lx, ly: m.interior.ly };
+    }
+  }
+
+  // Goal-directed: if region-level goal points elsewhere, head to the matching
+  // edge tile so the NPC can transition out next tick.
+  const regionTarget = goalTarget(npc.goal, npc, npcs);
+  if (regionTarget && (regionTarget.rx !== here.rx || regionTarget.ry !== here.ry)) {
+    const dx = regionTarget.rx - here.rx;
+    const dy = regionTarget.ry - here.ry;
+    if (Math.abs(dx) >= Math.abs(dy) && dx !== 0) {
+      return { lx: dx > 0 ? INTERIOR_W - 1 : 0, ly: clamp(npc.interior!.ly, 0, INTERIOR_H - 1) };
+    }
+    if (dy !== 0) {
+      return { lx: clamp(npc.interior!.lx, 0, INTERIOR_W - 1), ly: dy > 0 ? INTERIOR_H - 1 : 0 };
+    }
+  }
+
+  // Default wander: pick the interior centre as a soft anchor to avoid
+  // clustering at the spawn edge.
+  const cx = Math.floor(INTERIOR_W / 2);
+  const cy = Math.floor(INTERIOR_H / 2);
+  return { lx: cx, ly: cy };
+}
+
+function wantsToLeaveRegion(
+  npc: Npc,
+  here: { rx: number; ry: number },
+): boolean {
+  const t = goalTarget(npc.goal, npc, []);
+  if (!t) return false;
+  return t.rx !== here.rx || t.ry !== here.ry;
+}
+
+function isEdgeTile(lx: number, ly: number): boolean {
+  return lx === 0 || ly === 0 || lx === INTERIOR_W - 1 || ly === INTERIOR_H - 1;
+}
+
+function neighborRegionForEdge(
+  rx: number,
+  ry: number,
+  lx: number,
+  ly: number,
+  mapW: number,
+  mapH: number,
+): { rx: number; ry: number } | null {
+  let nrx = rx;
+  let nry = ry;
+  if (lx === 0) nrx -= 1;
+  else if (lx === INTERIOR_W - 1) nrx += 1;
+  else if (ly === 0) nry -= 1;
+  else if (ly === INTERIOR_H - 1) nry += 1;
+  else return null;
+  if (!isPassable(nrx, nry, mapW, mapH)) return null;
+  return { rx: nrx, ry: nry };
+}
+
+function randomNearby(lx: number, ly: number, rng: Rng): { lx: number; ly: number } {
+  const choices: Array<[number, number]> = [
+    [lx + 1, ly],
+    [lx - 1, ly],
+    [lx, ly + 1],
+    [lx, ly - 1],
+  ];
+  const pick = choices[rng.int(0, choices.length)]!;
+  return { lx: pick[0], ly: pick[1] };
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  if (v < lo) return lo;
+  if (v > hi) return hi;
+  return v;
+}
+
+function attackPlayer(
+  res: CombatResult,
+  attacker: Npc,
+  rng: Rng,
+): { npc: Npc } {
+  if (!res.player) return { npc: attacker };
+  const bonus = weaponAttackBonus(attacker.weapon);
+  const damage = Math.max(1, attacker.combatAttack + bonus - res.player.stats.defense);
+  const newHealth = Math.max(0, res.player.health - damage);
+  const newPlayer: Player = { ...res.player, health: newHealth };
+  res.player = newPlayer;
+  res.hits.push({
+    defenderKind: "player",
+    attackerName: attacker.name,
+    damage,
+  });
+  if (newHealth === 0) {
+    res.playerKilledBy = {
+      npcId: attacker.id,
+      name: attacker.name,
+      factionId: attacker.factionId,
+    };
+  }
+  let nextWeapon: WeaponInstance | null = attacker.weapon;
+  if (attacker.weapon) {
+    const remaining = attacker.weapon.usesLeft - 1;
+    nextWeapon = remaining > 0 ? { kind: attacker.weapon.kind, usesLeft: remaining } : null;
+  }
+  return {
+    npc: {
+      ...attacker,
+      weapon: nextWeapon,
+      combatCooldown: COMBAT_COOLDOWN_TICKS,
+      combatIntent: "attack",
+    },
+  };
+}
+
+function attackNpcByNpc(
+  res: CombatResult,
+  attacker: Npc,
+  defender: Npc,
+  rng: Rng,
+): { attacker: Npc; defender: Npc } {
+  const bonus = weaponAttackBonus(attacker.weapon);
+  const damage = Math.max(1, attacker.combatAttack + bonus - defender.combatDefense);
+  const newHealth = Math.max(0, defender.combatHealth - damage);
+  res.hits.push({
+    defenderKind: "npc",
+    defenderId: defender.id,
+    attackerName: attacker.name,
+    damage,
+    lx: defender.interior?.lx,
+    ly: defender.interior?.ly,
+  });
+  let nextWeapon: WeaponInstance | null = attacker.weapon;
+  if (attacker.weapon) {
+    const remaining = attacker.weapon.usesLeft - 1;
+    nextWeapon = remaining > 0 ? { kind: attacker.weapon.kind, usesLeft: remaining } : null;
+  }
+  const updatedAttacker: Npc = {
+    ...attacker,
+    weapon: nextWeapon,
+    combatCooldown: COMBAT_COOLDOWN_TICKS,
+    combatIntent: "attack",
+  };
+  const updatedDefender: Npc = {
+    ...defender,
+    combatHealth: newHealth,
+    interior: defender.interior
+      ? { ...defender.interior, lastHitTick: defender.interior.lastHitTick }
+      : defender.interior,
+  };
+  if (newHealth === 0) {
+    res.deaths.push({
+      npcId: defender.id,
+      factionId: defender.factionId,
+      name: defender.name,
+      killerKind: "npc",
+      killerId: attacker.id,
+      killerName: attacker.name,
+    });
+    if (defender.interior) {
+      const interior = res.interiors[regionKey(defender.rx, defender.ry)];
+      if (interior) {
+        const pile = lootPileFor(defender, defender.interior, res, rng);
+        res.interiors = {
+          ...res.interiors,
+          [regionKey(defender.rx, defender.ry)]: addLoot(interior, pile),
+        };
+      }
+    }
+    res.factions = nudgePower(res.factions, attacker.factionId, 1);
+    res.factions = nudgePower(res.factions, defender.factionId, -1);
+    res.factionRelations = nudgeRelation(
+      res.factionRelations,
+      attacker.factionId,
+      defender.factionId,
+      -2,
+    );
+  }
+  return { attacker: updatedAttacker, defender: updatedDefender };
+}
+
+function lootPileFor(
+  npc: Npc,
+  interior: NpcInterior,
+  res: CombatResult,
+  rng: Rng,
+): LootPile {
+  const items: Partial<Record<ResourceKind, number>> = {};
+  // Faction-flavoured single-resource drop (deterministic rng draw).
+  const choices: ResourceKind[] = ["wood", "stone", "reed"];
+  const pick = choices[rng.int(0, choices.length)]!;
+  items[pick] = 1;
+  return {
+    id: `loot-${npc.id}-${res.npcs.length}`,
+    lx: interior.lx,
+    ly: interior.ly,
+    items,
+  };
+}
+
+function runRegionCombat(
+  res: CombatResult,
+  rng: Rng,
+  mapW: number,
+  mapH: number,
+): void {
+  // Group NPCs by region (excluding the player's region — handled by interior
+  // combat). For each region with multiple NPCs, sample a few hostile pairs
+  // and exchange damage.
+  const player = res.player;
+  const playerRegion = player ? globalToLocal(player.gx, player.gy) : null;
+  const groups = new Map<string, number[]>();
+  for (let i = 0; i < res.npcs.length; i++) {
+    const n = res.npcs[i]!;
+    if (n.combatHealth <= 0) continue;
+    if (
+      playerRegion &&
+      n.rx === playerRegion.rx &&
+      n.ry === playerRegion.ry
+    ) {
+      continue;
+    }
+    const key = regionKey(n.rx, n.ry);
+    const arr = groups.get(key) ?? [];
+    arr.push(i);
+    groups.set(key, arr);
+  }
+
+  let hits = 0;
+  const npcs = res.npcs.slice();
+  for (const [, idxs] of groups) {
+    if (idxs.length < 2) continue;
+    let pairsTried = 0;
+    for (let a = 0; a < idxs.length && pairsTried < REGION_PAIRS_PER_TICK; a++) {
+      for (let b = a + 1; b < idxs.length && pairsTried < REGION_PAIRS_PER_TICK; b++) {
+        const ai = idxs[a]!;
+        const bi = idxs[b]!;
+        const A = npcs[ai]!;
+        const B = npcs[bi]!;
+        if (A.combatHealth <= 0 || B.combatHealth <= 0) continue;
+        if (
+          !isFactionHostile(
+            res.factionRelations,
+            A.values,
+            B.values,
+            A.factionId,
+            B.factionId,
+          )
+        ) {
+          continue;
+        }
+        pairsTried++;
+        if (hits >= MAX_REGION_HITS_PER_TICK) break;
+
+        const aCool = Math.max(0, A.combatCooldown - 1);
+        const bCool = Math.max(0, B.combatCooldown - 1);
+
+        let updatedA: Npc = { ...A, combatCooldown: aCool };
+        let updatedB: Npc = { ...B, combatCooldown: bCool };
+
+        if (aCool === 0) {
+          const dmg = Math.max(1, A.combatAttack + weaponAttackBonus(A.weapon) - B.combatDefense);
+          updatedB = { ...updatedB, combatHealth: Math.max(0, updatedB.combatHealth - dmg) };
+          updatedA = { ...updatedA, combatCooldown: COMBAT_COOLDOWN_TICKS };
+          hits++;
+          if (updatedB.combatHealth === 0) {
+            res.deaths.push({
+              npcId: updatedB.id,
+              factionId: updatedB.factionId,
+              name: updatedB.name,
+              killerKind: "npc",
+              killerId: updatedA.id,
+              killerName: updatedA.name,
+            });
+            res.factions = nudgePower(res.factions, updatedA.factionId, 1);
+            res.factions = nudgePower(res.factions, updatedB.factionId, -1);
+            res.factionRelations = nudgeRelation(
+              res.factionRelations,
+              updatedA.factionId,
+              updatedB.factionId,
+              -2,
+            );
+          }
+        }
+        if (bCool === 0 && updatedB.combatHealth > 0) {
+          const dmg = Math.max(1, updatedB.combatAttack + weaponAttackBonus(updatedB.weapon) - updatedA.combatDefense);
+          updatedA = { ...updatedA, combatHealth: Math.max(0, updatedA.combatHealth - dmg) };
+          updatedB = { ...updatedB, combatCooldown: COMBAT_COOLDOWN_TICKS };
+          hits++;
+          if (updatedA.combatHealth === 0) {
+            res.deaths.push({
+              npcId: updatedA.id,
+              factionId: updatedA.factionId,
+              name: updatedA.name,
+              killerKind: "npc",
+              killerId: updatedB.id,
+              killerName: updatedB.name,
+            });
+            res.factions = nudgePower(res.factions, updatedB.factionId, 1);
+            res.factions = nudgePower(res.factions, updatedA.factionId, -1);
+            res.factionRelations = nudgeRelation(
+              res.factionRelations,
+              updatedB.factionId,
+              updatedA.factionId,
+              -2,
+            );
+          }
+        }
+
+        npcs[ai] = updatedA;
+        npcs[bi] = updatedB;
+      }
+    }
+  }
+  res.npcs = npcs;
+}
+
+export function pruneDeadNpcs(npcs: Npc[]): Npc[] {
+  return npcs.filter((n) => n.combatHealth > 0);
+}
+
+// Player-initiated attack: called from player-tick when pendingAction kicks in.
+export function resolvePlayerAttack(
+  player: Player,
+  npc: Npc,
+  rng: Rng,
+): {
+  player: Player;
+  npc: Npc;
+  hits: CombatHit[];
+  deaths: CombatDeath[];
+  loot: LootPile | null;
+  repPenaltyFactionId: string;
+  repPenaltyAmount: number;
+  attacked: boolean;
+} {
+  if (!npc.interior || player.combatCooldown > 0) {
+    return {
+      player,
+      npc,
+      hits: [],
+      deaths: [],
+      loot: null,
+      repPenaltyFactionId: npc.factionId,
+      repPenaltyAmount: 0,
+      attacked: false,
+    };
+  }
+  const here = globalToLocal(player.gx, player.gy);
+  const dist = chebyshev(here.lx, here.ly, npc.interior.lx, npc.interior.ly);
+  const weapon = pickWeaponForRange(player.weapons, dist);
+  const reach = weapon ? weaponReach(weapon) : player.stats.reach;
+  if (dist > reach) {
+    return {
+      player,
+      npc,
+      hits: [],
+      deaths: [],
+      loot: null,
+      repPenaltyFactionId: npc.factionId,
+      repPenaltyAmount: 0,
+      attacked: false,
+    };
+  }
+  const damage = Math.max(
+    1,
+    player.stats.attack + weaponAttackBonus(weapon) - npc.combatDefense,
+  );
+  const nextNpcHealth = Math.max(0, npc.combatHealth - damage);
+  const nextWeapons = weapon ? consumeUse(player.weapons, weapon.kind) : player.weapons;
+  const nextPlayer: Player = {
+    ...player,
+    weapons: nextWeapons,
+    combatCooldown: COMBAT_COOLDOWN_TICKS,
+    pendingAction: null,
+  };
+  const updatedNpc: Npc = { ...npc, combatHealth: nextNpcHealth };
+  const hits: CombatHit[] = [
+    {
+      defenderKind: "npc",
+      defenderId: npc.id,
+      attackerName: "You",
+      damage,
+      lx: npc.interior.lx,
+      ly: npc.interior.ly,
+    },
+  ];
+  const deaths: CombatDeath[] = [];
+  let loot: LootPile | null = null;
+  let repPenaltyAmount = 5;
+  if (nextNpcHealth === 0) {
+    deaths.push({
+      npcId: npc.id,
+      factionId: npc.factionId,
+      name: npc.name,
+      killerKind: "player",
+    });
+    repPenaltyAmount = 15;
+    const items: Partial<Record<ResourceKind, number>> = {};
+    const choices: ResourceKind[] = ["wood", "stone", "reed"];
+    const pick = choices[rng.int(0, choices.length)]!;
+    items[pick] = 1;
+    loot = {
+      id: `loot-${npc.id}-p`,
+      lx: npc.interior.lx,
+      ly: npc.interior.ly,
+      items,
+    };
+  }
+  return {
+    player: nextPlayer,
+    npc: updatedNpc,
+    hits,
+    deaths,
+    loot,
+    repPenaltyFactionId: npc.factionId,
+    repPenaltyAmount,
+    attacked: true,
+  };
+}
+
+export function applyRepPenalty(
+  playerReputation: Record<string, number>,
+  factionId: string,
+  amount: number,
+): Record<string, number> {
+  if (amount <= 0) return playerReputation;
+  return losePlayerRep(playerReputation, factionId, amount);
+}
+
+export function chebyshev(ax: number, ay: number, bx: number, by: number): number {
+  return Math.max(Math.abs(ax - bx), Math.abs(ay - by));
+}

--- a/lib/sim/combat.ts
+++ b/lib/sim/combat.ts
@@ -319,7 +319,7 @@ function stepTowardTarget(
     target.lx === interiorPos.lx &&
     target.ly === interiorPos.ly &&
     isEdgeTile(target.lx, target.ly) &&
-    wantsToLeaveRegion(npc, here)
+    wantsToLeaveRegion(npc, here, npcs)
   ) {
     const transit = neighborRegionForEdge(here.rx, here.ry, target.lx, target.ly, mapW, mapH);
     if (transit) return { next: null, tileIntent: null, transitioned: transit };
@@ -345,7 +345,7 @@ function stepTowardTarget(
     step.px === target.lx &&
     step.py === target.ly &&
     isEdgeTile(step.px, step.py) &&
-    wantsToLeaveRegion(npc, here)
+    wantsToLeaveRegion(npc, here, npcs)
   ) {
     const transit = neighborRegionForEdge(here.rx, here.ry, step.px, step.py, mapW, mapH);
     if (transit) return { next: null, tileIntent: null, transitioned: transit };
@@ -433,6 +433,19 @@ function pickDynamicTileTarget(
     }
   }
 
+  // Trade peer in this interior: walk to them so the goal can register as
+  // done at tile level. Without this they'd both wander past each other.
+  if (npc.goal.kind === "trade") {
+    const peerId = npc.goal.peerNpcId;
+    for (const j of inHere) {
+      if (j === selfIdx) continue;
+      const m = npcs[j]!;
+      if (m.id !== peerId) continue;
+      if (!m.interior) continue;
+      return { lx: m.interior.lx, ly: m.interior.ly };
+    }
+  }
+
   const regionTarget = goalTarget(npc.goal, npc, npcs);
   if (regionTarget && (regionTarget.rx !== here.rx || regionTarget.ry !== here.ry)) {
     const dx = regionTarget.rx - here.rx;
@@ -450,8 +463,9 @@ function pickDynamicTileTarget(
 function wantsToLeaveRegion(
   npc: Npc,
   here: { rx: number; ry: number },
+  npcs: Npc[],
 ): boolean {
-  const t = goalTarget(npc.goal, npc, []);
+  const t = goalTarget(npc.goal, npc, npcs);
   if (!t) return false;
   return t.rx !== here.rx || t.ry !== here.ry;
 }

--- a/lib/sim/combat.ts
+++ b/lib/sim/combat.ts
@@ -35,6 +35,9 @@ export const TILE_STEP_COOLDOWN_MIN = 1;
 export const TILE_STEP_COOLDOWN_MAX = 4;
 export const REGION_PAIRS_PER_TICK = 4;
 export const MAX_REGION_HITS_PER_TICK = 6;
+// How long a hit lingers as "engaged" on an NPC's mind. After this many
+// ticks of no follow-up, they drop pursuit.
+export const ENGAGED_TTL_TICKS = 200;
 
 export type CombatHit = {
   defenderKind: "player" | "npc";
@@ -75,6 +78,7 @@ export type CombatInput = {
   playerReputation: Record<string, number>;
   mapW: number;
   mapH: number;
+  ticks: number;
 };
 
 export function tickCombat(input: CombatInput, rng: Rng): CombatResult {
@@ -93,9 +97,9 @@ export function tickCombat(input: CombatInput, rng: Rng): CombatResult {
   // abstract combat. This keeps the player's neighbourhood crisp and lets
   // off-screen kills affect faction power before encounter detection.
   if (result.player) {
-    runInteriorCombat(result, rng, input.mapW, input.mapH);
+    runInteriorCombat(result, rng, input.mapW, input.mapH, input.ticks);
   }
-  runRegionCombat(result, rng, input.mapW, input.mapH);
+  runRegionCombat(result, rng, input.mapW, input.mapH, input.ticks);
   return result;
 }
 
@@ -104,6 +108,7 @@ function runInteriorCombat(
   rng: Rng,
   mapW: number,
   mapH: number,
+  ticks: number,
 ): void {
   const player = res.player;
   if (!player) return;
@@ -156,6 +161,7 @@ function runInteriorCombat(
         tileIntent: null,
         stepCooldown: rng.int(TILE_STEP_COOLDOWN_MIN, TILE_STEP_COOLDOWN_MAX + 1),
         lastHitTick: -999,
+        wanderUntil: ticks + rng.int(40, 100),
       },
     };
   }
@@ -225,7 +231,7 @@ function runInteriorCombat(
       };
       continue;
     }
-    const stepped = stepTowardTarget(n, npcs, inHere, idx, here, interior, mapW, mapH, res, rng);
+    const stepped = stepTowardTarget(n, npcs, inHere, idx, here, interior, mapW, mapH, res, rng, ticks);
     if (stepped.transitioned) {
       // NPC left the player's region; clear interior, advance rx/ry.
       npcs[idx] = {
@@ -279,6 +285,7 @@ function stepTowardTarget(
   mapH: number,
   res: CombatResult,
   rng: Rng,
+  ticks: number,
 ): StepResult {
   const interiorPos = npc.interior!;
 
@@ -292,7 +299,7 @@ function stepTowardTarget(
     occupied[m.interior.ly * INTERIOR_W + m.interior.lx] = true;
   }
 
-  const dynamicTarget = pickDynamicTileTarget(npc, npcs, inHere, selfIdx, here, res);
+  const dynamicTarget = pickDynamicTileTarget(npc, npcs, inHere, selfIdx, here, res, ticks, rng);
 
   // Decide effective target: dynamic (player/enemy/edge) overrides any cached
   // wander; otherwise reuse cached tileIntent until we arrive, then reroll.
@@ -319,7 +326,7 @@ function stepTowardTarget(
     target.lx === interiorPos.lx &&
     target.ly === interiorPos.ly &&
     isEdgeTile(target.lx, target.ly) &&
-    wantsToLeaveRegion(npc, here, npcs)
+    wantsToLeaveRegion(npc, here, npcs, ticks)
   ) {
     const transit = neighborRegionForEdge(here.rx, here.ry, target.lx, target.ly, mapW, mapH);
     if (transit) return { next: null, tileIntent: null, transitioned: transit };
@@ -345,7 +352,7 @@ function stepTowardTarget(
     step.px === target.lx &&
     step.py === target.ly &&
     isEdgeTile(step.px, step.py) &&
-    wantsToLeaveRegion(npc, here, npcs)
+    wantsToLeaveRegion(npc, here, npcs, ticks)
   ) {
     const transit = neighborRegionForEdge(here.rx, here.ry, step.px, step.py, mapW, mapH);
     if (transit) return { next: null, tileIntent: null, transitioned: transit };
@@ -410,9 +417,12 @@ function pickDynamicTileTarget(
   selfIdx: number,
   here: { rx: number; ry: number; lx: number; ly: number },
   res: CombatResult,
+  ticks: number,
+  rng: Rng,
 ): { lx: number; ly: number } | null {
-  const playerHostile = (res.playerReputation[npc.factionId] ?? 0) < 0;
-  if (playerHostile && res.player) {
+  const repHostile = (res.playerReputation[npc.factionId] ?? 0) < 0;
+  const engaged = npc.engagedTick !== null && ticks - npc.engagedTick < ENGAGED_TTL_TICKS;
+  if ((repHostile || engaged) && res.player) {
     return { lx: here.lx, ly: here.ly };
   }
 
@@ -457,14 +467,43 @@ function pickDynamicTileTarget(
       return { lx: clamp(npc.interior!.lx, 0, INTERIOR_W - 1), ly: dy > 0 ? INTERIOR_H - 1 : 0 };
     }
   }
+
+  // Wandering NPCs that have been milling around long enough should head to
+  // an edge tile so they migrate out of the player's region naturally instead
+  // of looping inside forever.
+  if (npc.interior && ticks >= npc.interior.wanderUntil) {
+    return pickRandomEdgeTile(npc.interior.lx, npc.interior.ly, rng);
+  }
   return null;
+}
+
+function pickRandomEdgeTile(
+  lx: number,
+  ly: number,
+  rng: Rng,
+): { lx: number; ly: number } {
+  const side = rng.int(0, 4);
+  switch (side) {
+    case 0:
+      return { lx: clamp(lx + rng.int(-3, 4), 0, INTERIOR_W - 1), ly: 0 };
+    case 1:
+      return { lx: INTERIOR_W - 1, ly: clamp(ly + rng.int(-3, 4), 0, INTERIOR_H - 1) };
+    case 2:
+      return { lx: clamp(lx + rng.int(-3, 4), 0, INTERIOR_W - 1), ly: INTERIOR_H - 1 };
+    default:
+      return { lx: 0, ly: clamp(ly + rng.int(-3, 4), 0, INTERIOR_H - 1) };
+  }
 }
 
 function wantsToLeaveRegion(
   npc: Npc,
   here: { rx: number; ry: number },
   npcs: Npc[],
+  ticks: number,
 ): boolean {
+  // Wandering NPCs whose dwell timer has lapsed should drift out so they
+  // don't loop inside the player's interior forever.
+  if (npc.interior && ticks >= npc.interior.wanderUntil) return true;
   const t = goalTarget(npc.goal, npc, npcs);
   if (!t) return false;
   return t.rx !== here.rx || t.ry !== here.ry;
@@ -625,8 +664,9 @@ function lootPileFor(
 function runRegionCombat(
   res: CombatResult,
   rng: Rng,
-  mapW: number,
-  mapH: number,
+  _mapW: number,
+  _mapH: number,
+  _ticks: number,
 ): void {
   // Group NPCs by region (excluding the player's region — handled by interior
   // combat). For each region with multiple NPCs, sample a few hostile pairs
@@ -748,6 +788,7 @@ export function resolvePlayerAttack(
   player: Player,
   npc: Npc,
   rng: Rng,
+  ticks: number,
 ): {
   player: Player;
   npc: Npc;
@@ -798,7 +839,11 @@ export function resolvePlayerAttack(
     combatCooldown: COMBAT_COOLDOWN_TICKS,
     pendingAction: null,
   };
-  const updatedNpc: Npc = { ...npc, combatHealth: nextNpcHealth };
+  const updatedNpc: Npc = {
+    ...npc,
+    combatHealth: nextNpcHealth,
+    engagedTick: ticks,
+  };
   const hits: CombatHit[] = [
     {
       defenderKind: "npc",

--- a/lib/sim/events.ts
+++ b/lib/sim/events.ts
@@ -53,7 +53,9 @@ export function buildEncounterEvent(
   faction: FactionState,
   rng: Rng,
 ): WorldEvent {
-  const sentiment: EncounterSentiment = faction.reputation >= 0 ? "friendly" : "hostile";
+  const playerRep = world.playerReputation[npc.factionId];
+  const repForSentiment = playerRep ?? faction.reputation;
+  const sentiment: EncounterSentiment = repForSentiment >= 0 ? "friendly" : "hostile";
   const factionName = faction.name;
   if (sentiment === "friendly") {
     const offer = pickOffer(npc, rng);

--- a/lib/sim/faction.ts
+++ b/lib/sim/faction.ts
@@ -39,6 +39,16 @@ export function loseRep(
   return gainRep(factions, factionId, -Math.abs(delta));
 }
 
+export function nudgePower(
+  factions: FactionState[],
+  factionId: string,
+  delta: number,
+): FactionState[] {
+  return factions.map((f) =>
+    f.id === factionId ? { ...f, power: clampPower(f.power + delta) } : f,
+  );
+}
+
 export function findFaction(
   factions: FactionState[],
   factionId: string,
@@ -50,4 +60,75 @@ function clampRep(value: number): number {
   if (value < REPUTATION_MIN) return REPUTATION_MIN;
   if (value > REPUTATION_MAX) return REPUTATION_MAX;
   return value;
+}
+
+function clampPower(value: number): number {
+  if (value < 0) return 0;
+  if (value > 100) return 100;
+  return value;
+}
+
+export function playerRepOf(
+  playerReputation: Record<string, number>,
+  factionId: string,
+): number {
+  return playerReputation[factionId] ?? 0;
+}
+
+export function gainPlayerRep(
+  playerReputation: Record<string, number>,
+  factionId: string,
+  delta: number,
+): Record<string, number> {
+  const cur = playerReputation[factionId] ?? 0;
+  return { ...playerReputation, [factionId]: clampRep(cur + delta) };
+}
+
+export function losePlayerRep(
+  playerReputation: Record<string, number>,
+  factionId: string,
+  delta: number,
+): Record<string, number> {
+  return gainPlayerRep(playerReputation, factionId, -Math.abs(delta));
+}
+
+export function pairKey(a: string, b: string): string {
+  return a < b ? `${a}|${b}` : `${b}|${a}`;
+}
+
+export function getRelation(
+  factionRelations: Record<string, number>,
+  a: string,
+  b: string,
+): number {
+  if (a === b) return 0;
+  return factionRelations[pairKey(a, b)] ?? 0;
+}
+
+export function nudgeRelation(
+  factionRelations: Record<string, number>,
+  a: string,
+  b: string,
+  delta: number,
+): Record<string, number> {
+  if (a === b) return factionRelations;
+  const key = pairKey(a, b);
+  const cur = factionRelations[key] ?? 0;
+  return { ...factionRelations, [key]: clampRep(cur + delta) };
+}
+
+// Hostility between two NPCs of (potentially) different factions. Same faction
+// is never hostile. Otherwise hostile when relations have soured below zero
+// or either faction's values include `violence` (raiders pick fights).
+export function isFactionHostile(
+  factionRelations: Record<string, number>,
+  factionAValues: readonly string[],
+  factionBValues: readonly string[],
+  factionAId: string,
+  factionBId: string,
+): boolean {
+  if (factionAId === factionBId) return false;
+  if (getRelation(factionRelations, factionAId, factionBId) < 0) return true;
+  if (factionAValues.includes("violence") || factionBValues.includes("violence")) return true;
+  return false;
 }

--- a/lib/sim/npc.ts
+++ b/lib/sim/npc.ts
@@ -20,6 +20,7 @@ export type NpcInterior = {
   tileIntent: { lx: number; ly: number } | null;
   stepCooldown: number;
   lastHitTick: number;
+  wanderUntil: number;
 };
 
 export type CombatIntent = "approach" | "attack" | "flee" | null;
@@ -49,6 +50,9 @@ export type Npc = {
   combatIntent: CombatIntent;
   weapon: WeaponInstance | null;
   interior: NpcInterior | null;
+  // Tick at which the player last attacked this NPC. While set and recent,
+  // the NPC pursues the player as if hostile regardless of faction rep.
+  engagedTick: number | null;
 };
 
 const IDLE_MIN = 12;
@@ -112,6 +116,7 @@ export function spawnNpc(rng: Rng, id: number, mapW: number, mapH: number): Npc 
     combatIntent: null,
     weapon: null,
     interior: null,
+    engagedTick: null,
   };
 }
 

--- a/lib/sim/npc.ts
+++ b/lib/sim/npc.ts
@@ -10,8 +10,19 @@ import {
   GOAL_TTL_TICKS,
   type Goal,
 } from "@/lib/sim/goal";
+import type { WeaponInstance } from "@/lib/sim/weapons";
 
 export type Intent = { rx: number; ry: number };
+
+export type NpcInterior = {
+  lx: number;
+  ly: number;
+  tileIntent: { lx: number; ly: number } | null;
+  stepCooldown: number;
+  lastHitTick: number;
+};
+
+export type CombatIntent = "approach" | "attack" | "flee" | null;
 
 export type Npc = {
   id: string;
@@ -29,6 +40,15 @@ export type Npc = {
   goalTtl: number;
   stuckCounter: number;
   lastDistance: number;
+  combatHealth: number;
+  combatHealthMax: number;
+  combatAttack: number;
+  combatDefense: number;
+  combatReach: number;
+  combatCooldown: number;
+  combatIntent: CombatIntent;
+  weapon: WeaponInstance | null;
+  interior: NpcInterior | null;
 };
 
 const IDLE_MIN = 12;
@@ -58,27 +78,47 @@ export function spawnNpc(rng: Rng, id: number, mapW: number, mapH: number): Npc 
     }
   }
 
+  const values = [...faction.values];
+  let combatAttack = 1;
+  if (values.includes("violence")) combatAttack += 1;
+  if (traits.includes("brutish")) combatAttack += 1;
+  let combatDefense = 0;
+  if (traits.includes("cowardly")) combatDefense += 1;
+  if (traits.includes("patient")) combatDefense += 1;
+  const combatHealthMax = clampInt(4 + Math.round(50 / 25) + (traits.includes("brave") ? 1 : 0), 4, 8);
+
   return {
     id: `npc-${id}`,
     name: rng.pick(NAMES),
     factionId: faction.id,
     factionColor: faction.color,
     traits,
-    values: [...faction.values],
+    values,
     rx,
     ry,
     homeRegion: { rx, ry },
     intent: null,
     moveCooldown: rng.int(IDLE_MIN, IDLE_MAX),
     goal: { kind: "wander" },
-    // Stagger initial goal re-picks across the first ~15s so the population
-    // gets varied goals quickly without synchronising 200 pickGoal calls
-    // on tick 1. pickGoal needs live world state (regionControl, npcs)
-    // which spawnNpc doesn't have.
     goalTtl: rng.int(1, 60),
     stuckCounter: 0,
     lastDistance: -1,
+    combatHealth: combatHealthMax,
+    combatHealthMax,
+    combatAttack,
+    combatDefense,
+    combatReach: 1,
+    combatCooldown: 0,
+    combatIntent: null,
+    weapon: null,
+    interior: null,
   };
+}
+
+function clampInt(v: number, lo: number, hi: number): number {
+  if (v < lo) return lo;
+  if (v > hi) return hi;
+  return v;
 }
 
 export type TickNpcCtx = {
@@ -87,10 +127,22 @@ export type TickNpcCtx = {
   mapH: number;
   regionControl: Record<string, string>;
   npcs: Npc[];
+  playerRegion: { rx: number; ry: number } | null;
 };
 
 export function tickNpc(npc: Npc, ctx: TickNpcCtx): Npc {
   const { rng, mapW, mapH } = ctx;
+
+  // Combat tick owns movement for NPCs in the player's region.
+  if (
+    ctx.playerRegion &&
+    npc.rx === ctx.playerRegion.rx &&
+    npc.ry === ctx.playerRegion.ry
+  ) {
+    const cooldown = Math.max(0, (npc.moveCooldown ?? 0) - 1);
+    const combatCooldown = Math.max(0, (npc.combatCooldown ?? 0) - 1);
+    return { ...npc, moveCooldown: cooldown, combatCooldown };
+  }
 
   let goal = npc.goal;
   // Decrement once at the top so the TTL counts wall-clock ticks rather

--- a/lib/sim/player-tick.ts
+++ b/lib/sim/player-tick.ts
@@ -9,29 +9,44 @@ import {
 import {
   globalToLocal,
   isLocalObstacle,
+  lootAtLocal,
+  removeLoot,
   regionKey,
   removeResource,
   resourceAtLocal,
   type BiomeInterior,
 } from "@/lib/sim/biome-interior";
 import type { Inventory } from "@/lib/sim/inventory";
-import { RESOURCES } from "@/content/resources";
+import { RESOURCES, type ResourceKind } from "@/content/resources";
+import type { Npc } from "@/lib/sim/npc";
+import { applyRepPenalty, resolvePlayerAttack } from "@/lib/sim/combat";
+import type { Rng } from "@/lib/sim/rng";
 
 export type PlayerTickInput = {
   player: Player;
   interiors: Record<string, BiomeInterior>;
   inventory: Inventory;
+  npcs: Npc[];
+  playerReputation: Record<string, number>;
+  rng: Rng;
 };
 
 export type PlayerTickOutput = {
   player: Player;
   interiors: Record<string, BiomeInterior>;
   inventory: Inventory;
+  npcs: Npc[];
+  playerReputation: Record<string, number>;
   death: boolean;
 };
 
 export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
-  let { player, interiors, inventory } = input;
+  let { player, interiors, inventory, npcs, playerReputation } = input;
+  const rng = input.rng;
+
+  if (player.combatCooldown > 0) {
+    player = { ...player, combatCooldown: player.combatCooldown - 1 };
+  }
 
   // Walk one step when the cooldown is up.
   if (player.route && player.route.length > 0) {
@@ -62,6 +77,10 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
             energy,
             energyAccumDrain: nextAccum,
           };
+          // Auto-pickup loot at the new tile.
+          const picked = pickupLoot(player, interiors, inventory);
+          interiors = picked.interiors;
+          inventory = picked.inventory;
         }
       }
     }
@@ -76,6 +95,42 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
       player = result.player;
       interiors = result.interiors;
       inventory = result.inventory;
+    } else if (action.kind === "attack") {
+      const targetIdx = npcs.findIndex((n) => n.id === action.npcId);
+      if (targetIdx >= 0) {
+        const target = npcs[targetIdx]!;
+        const out = resolvePlayerAttack(player, target, rng);
+        if (out.attacked) {
+          player = out.player;
+          if (out.repPenaltyAmount > 0) {
+            playerReputation = applyRepPenalty(
+              playerReputation,
+              out.repPenaltyFactionId,
+              out.repPenaltyAmount,
+            );
+          }
+          if (out.npc.combatHealth <= 0) {
+            // Dead NPC: drop loot in interior; remove from list.
+            if (out.loot) {
+              const k = regionKey(out.npc.rx, out.npc.ry);
+              const interior = interiors[k];
+              if (interior) {
+                interiors = {
+                  ...interiors,
+                  [k]: { ...interior, loot: [...interior.loot, out.loot] },
+                };
+              }
+            }
+            const nextNpcs = npcs.slice();
+            nextNpcs.splice(targetIdx, 1);
+            npcs = nextNpcs;
+          } else {
+            const nextNpcs = npcs.slice();
+            nextNpcs[targetIdx] = out.npc;
+            npcs = nextNpcs;
+          }
+        }
+      }
     }
   }
 
@@ -96,6 +151,8 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
     player,
     interiors,
     inventory,
+    npcs,
+    playerReputation,
     death: player.health <= 0,
   };
 }
@@ -103,6 +160,11 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
 export function setPendingCollect(player: Player, resourceId: string): Player {
   const action: PendingAction = { kind: "collect", resourceId };
   return { ...player, pendingAction: action };
+}
+
+export function setPendingAttack(player: Player, npcId: string): Player {
+  const action: PendingAction = { kind: "attack", npcId };
+  return { ...player, pendingAction: action, route: null, stepCooldown: 0 };
 }
 
 function tryCollect(
@@ -135,6 +197,29 @@ function tryCollect(
   }
 
   return { player: nextPlayer, interiors: updatedInteriors, inventory: updatedInventory };
+}
+
+function pickupLoot(
+  player: Player,
+  interiors: Record<string, BiomeInterior>,
+  inventory: Inventory,
+): { interiors: Record<string, BiomeInterior>; inventory: Inventory } {
+  const { rx, ry, lx, ly } = globalToLocal(player.gx, player.gy);
+  const k = regionKey(rx, ry);
+  const interior = interiors[k];
+  if (!interior) return { interiors, inventory };
+  const pile = lootAtLocal(interior, lx, ly);
+  if (!pile) return { interiors, inventory };
+  let nextInventory: Inventory = { ...inventory };
+  for (const key of Object.keys(pile.items) as ResourceKind[]) {
+    const amt = pile.items[key] ?? 0;
+    if (amt <= 0) continue;
+    nextInventory[key] = (nextInventory[key] ?? 0) + amt;
+  }
+  return {
+    interiors: { ...interiors, [k]: removeLoot(interior, pile.id) },
+    inventory: nextInventory,
+  };
 }
 
 function isStepBlocked(

--- a/lib/sim/player-tick.ts
+++ b/lib/sim/player-tick.ts
@@ -1,6 +1,4 @@
 import {
-  EAT_ENERGY_PER_FOOD,
-  EAT_HEALTH_PER_FOOD,
   STARVE_TICKS_PER_DAMAGE,
   WALK_ENERGY_PER_STEP,
   type PendingAction,
@@ -17,7 +15,7 @@ import {
   type BiomeInterior,
 } from "@/lib/sim/biome-interior";
 import type { Inventory } from "@/lib/sim/inventory";
-import { RESOURCES, type ResourceKind } from "@/content/resources";
+import type { ResourceKind } from "@/content/resources";
 import type { Npc } from "@/lib/sim/npc";
 import { applyRepPenalty, resolvePlayerAttack } from "@/lib/sim/combat";
 import type { Rng } from "@/lib/sim/rng";
@@ -197,7 +195,6 @@ function tryCollect(
     return { player, interiors, inventory, pickup: null };
   }
 
-  const meta = RESOURCES[resource.kind];
   const updatedInterior = removeResource(interior, resource.id);
   const updatedInteriors = { ...interiors, [regionKey(rx, ry)]: updatedInterior };
   const updatedInventory: Inventory = {
@@ -205,17 +202,8 @@ function tryCollect(
     [resource.kind]: (inventory[resource.kind] ?? 0) + 1,
   };
 
-  let nextPlayer = player;
-  if (meta.food) {
-    nextPlayer = {
-      ...player,
-      energy: Math.min(player.energyMax, player.energy + EAT_ENERGY_PER_FOOD),
-      health: Math.min(player.healthMax, player.health + EAT_HEALTH_PER_FOOD),
-    };
-  }
-
   return {
-    player: nextPlayer,
+    player,
     interiors: updatedInteriors,
     inventory: updatedInventory,
     pickup: { kind: resource.kind, amount: 1 },

--- a/lib/sim/player-tick.ts
+++ b/lib/sim/player-tick.ts
@@ -22,6 +22,11 @@ import type { Npc } from "@/lib/sim/npc";
 import { applyRepPenalty, resolvePlayerAttack } from "@/lib/sim/combat";
 import type { Rng } from "@/lib/sim/rng";
 
+export type PickupNotice = {
+  kind: ResourceKind;
+  amount: number;
+};
+
 export type PlayerTickInput = {
   player: Player;
   interiors: Record<string, BiomeInterior>;
@@ -29,6 +34,7 @@ export type PlayerTickInput = {
   npcs: Npc[];
   playerReputation: Record<string, number>;
   rng: Rng;
+  ticks: number;
 };
 
 export type PlayerTickOutput = {
@@ -37,12 +43,14 @@ export type PlayerTickOutput = {
   inventory: Inventory;
   npcs: Npc[];
   playerReputation: Record<string, number>;
+  pickups: PickupNotice[];
   death: boolean;
 };
 
 export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
   let { player, interiors, inventory, npcs, playerReputation } = input;
   const rng = input.rng;
+  const pickups: PickupNotice[] = [];
 
   if (player.combatCooldown > 0) {
     player = { ...player, combatCooldown: player.combatCooldown - 1 };
@@ -81,6 +89,7 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
           const picked = pickupLoot(player, interiors, inventory);
           interiors = picked.interiors;
           inventory = picked.inventory;
+          for (const p of picked.pickups) pickups.push(p);
         }
       }
     }
@@ -95,6 +104,7 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
       player = result.player;
       interiors = result.interiors;
       inventory = result.inventory;
+      if (result.pickup) pickups.push(result.pickup);
     } else if (action.kind === "attack") {
       const targetIdx = npcs.findIndex((n) => n.id === action.npcId);
       if (targetIdx >= 0) {
@@ -153,6 +163,7 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
     inventory,
     npcs,
     playerReputation,
+    pickups,
     death: player.health <= 0,
   };
 }
@@ -172,12 +183,19 @@ function tryCollect(
   interiors: Record<string, BiomeInterior>,
   inventory: Inventory,
   resourceId: string,
-): { player: Player; interiors: Record<string, BiomeInterior>; inventory: Inventory } {
+): {
+  player: Player;
+  interiors: Record<string, BiomeInterior>;
+  inventory: Inventory;
+  pickup: PickupNotice | null;
+} {
   const { rx, ry, lx, ly } = globalToLocal(player.gx, player.gy);
   const interior = interiors[regionKey(rx, ry)];
-  if (!interior) return { player, interiors, inventory };
+  if (!interior) return { player, interiors, inventory, pickup: null };
   const resource = resourceAtLocal(interior, lx, ly);
-  if (!resource || resource.id !== resourceId) return { player, interiors, inventory };
+  if (!resource || resource.id !== resourceId) {
+    return { player, interiors, inventory, pickup: null };
+  }
 
   const meta = RESOURCES[resource.kind];
   const updatedInterior = removeResource(interior, resource.id);
@@ -196,29 +214,41 @@ function tryCollect(
     };
   }
 
-  return { player: nextPlayer, interiors: updatedInteriors, inventory: updatedInventory };
+  return {
+    player: nextPlayer,
+    interiors: updatedInteriors,
+    inventory: updatedInventory,
+    pickup: { kind: resource.kind, amount: 1 },
+  };
 }
 
 function pickupLoot(
   player: Player,
   interiors: Record<string, BiomeInterior>,
   inventory: Inventory,
-): { interiors: Record<string, BiomeInterior>; inventory: Inventory } {
+): {
+  interiors: Record<string, BiomeInterior>;
+  inventory: Inventory;
+  pickups: PickupNotice[];
+} {
   const { rx, ry, lx, ly } = globalToLocal(player.gx, player.gy);
   const k = regionKey(rx, ry);
   const interior = interiors[k];
-  if (!interior) return { interiors, inventory };
+  if (!interior) return { interiors, inventory, pickups: [] };
   const pile = lootAtLocal(interior, lx, ly);
-  if (!pile) return { interiors, inventory };
-  let nextInventory: Inventory = { ...inventory };
+  if (!pile) return { interiors, inventory, pickups: [] };
+  const nextInventory: Inventory = { ...inventory };
+  const pickups: PickupNotice[] = [];
   for (const key of Object.keys(pile.items) as ResourceKind[]) {
     const amt = pile.items[key] ?? 0;
     if (amt <= 0) continue;
     nextInventory[key] = (nextInventory[key] ?? 0) + amt;
+    pickups.push({ kind: key, amount: amt });
   }
   return {
     interiors: { ...interiors, [k]: removeLoot(interior, pile.id) },
     inventory: nextInventory,
+    pickups,
   };
 }
 

--- a/lib/sim/player-tick.ts
+++ b/lib/sim/player-tick.ts
@@ -5,8 +5,11 @@ import {
   type Player,
 } from "@/lib/sim/player";
 import {
+  INTERIOR_W,
+  INTERIOR_H,
   globalToLocal,
   isLocalObstacle,
+  localToGlobal,
   lootAtLocal,
   removeLoot,
   regionKey,
@@ -17,7 +20,9 @@ import {
 import type { Inventory } from "@/lib/sim/inventory";
 import type { ResourceKind } from "@/content/resources";
 import type { Npc } from "@/lib/sim/npc";
-import { applyRepPenalty, resolvePlayerAttack } from "@/lib/sim/combat";
+import { applyRepPenalty, resolvePlayerAttack, chebyshev } from "@/lib/sim/combat";
+import { pickWeaponForRange, weaponReach } from "@/lib/sim/weapons";
+import { bfs } from "@/lib/sim/path";
 import type { Rng } from "@/lib/sim/rng";
 
 export type PickupNotice = {
@@ -48,10 +53,44 @@ export type PlayerTickOutput = {
 export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
   let { player, interiors, inventory, npcs, playerReputation } = input;
   const rng = input.rng;
+  const ticks = input.ticks;
   const pickups: PickupNotice[] = [];
 
   if (player.combatCooldown > 0) {
     player = { ...player, combatCooldown: player.combatCooldown - 1 };
+  }
+
+  // Attack pending: keep chasing the NPC until they die, leave the region,
+  // or the player cancels by walking somewhere else. We re-plot the route
+  // each tick the player isn't already in reach.
+  if (player.pendingAction?.kind === "attack") {
+    const attackId = player.pendingAction.npcId;
+    const target = npcs.find((n) => n.id === attackId);
+    if (!target || target.combatHealth <= 0 || !target.interior) {
+      player = { ...player, pendingAction: null, route: null, stepCooldown: 0 };
+    } else {
+      const here = globalToLocal(player.gx, player.gy);
+      if (here.rx !== target.rx || here.ry !== target.ry) {
+        // Target moved out of the player's region; abandon the chase.
+        player = { ...player, pendingAction: null, route: null, stepCooldown: 0 };
+      } else {
+        const dist = chebyshev(here.lx, here.ly, target.interior.lx, target.interior.ly);
+        const weapon = pickWeaponForRange(player.weapons, dist);
+        const reach = weapon ? weaponReach(weapon) : player.stats.reach;
+        if (dist > reach) {
+          // Need to close the gap. Replot route only if we don't have one
+          // ending within reach of the target's current tile.
+          const rerouted = chasePlan(
+            player,
+            interiors,
+            target,
+            reach,
+            here,
+          );
+          if (rerouted) player = rerouted;
+        }
+      }
+    }
   }
 
   // Walk one step when the cooldown is up.
@@ -85,6 +124,7 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
           };
           // Auto-pickup loot at the new tile.
           const picked = pickupLoot(player, interiors, inventory);
+          player = picked.player;
           interiors = picked.interiors;
           inventory = picked.inventory;
           for (const p of picked.pickups) pickups.push(p);
@@ -96,8 +136,8 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
   // Fire pending action when route empties.
   if (player.route === null && player.pendingAction) {
     const action = player.pendingAction;
-    player = { ...player, pendingAction: null };
     if (action.kind === "collect") {
+      player = { ...player, pendingAction: null };
       const result = tryCollect(player, interiors, inventory, action.resourceId);
       player = result.player;
       interiors = result.interiors;
@@ -107,7 +147,7 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
       const targetIdx = npcs.findIndex((n) => n.id === action.npcId);
       if (targetIdx >= 0) {
         const target = npcs[targetIdx]!;
-        const out = resolvePlayerAttack(player, target, rng);
+        const out = resolvePlayerAttack(player, target, rng, ticks);
         if (out.attacked) {
           player = out.player;
           if (out.repPenaltyAmount > 0) {
@@ -116,6 +156,12 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
               out.repPenaltyFactionId,
               out.repPenaltyAmount,
             );
+          }
+          // Keep pendingAction set so we keep chasing if the target is still
+          // alive. resolvePlayerAttack already cleared it on success; restore
+          // it unless the NPC died.
+          if (out.npc.combatHealth > 0) {
+            player = { ...player, pendingAction: action };
           }
           if (out.npc.combatHealth <= 0) {
             // Dead NPC: drop loot in interior; remove from list.
@@ -176,6 +222,72 @@ export function setPendingAttack(player: Player, npcId: string): Player {
   return { ...player, pendingAction: action, route: null, stepCooldown: 0 };
 }
 
+// Plan a chase route to within `reach` of the NPC's current interior tile.
+// Returns the player with an updated route, or null if no plan is needed
+// (existing route already ends within reach of the target's current tile).
+function chasePlan(
+  player: Player,
+  interiors: Record<string, BiomeInterior>,
+  target: Npc,
+  reach: number,
+  here: { rx: number; ry: number; lx: number; ly: number },
+): Player | null {
+  if (!target.interior) return null;
+  const interior = interiors[regionKey(here.rx, here.ry)];
+  if (!interior) return null;
+
+  // If we already have a route whose final step lands within reach of the
+  // target's current tile, leave it alone.
+  if (player.route && player.route.length > 0) {
+    const last = player.route[player.route.length - 1]!;
+    const lastLocal = globalToLocal(last.gx, last.gy);
+    if (
+      lastLocal.rx === target.rx &&
+      lastLocal.ry === target.ry &&
+      Math.max(
+        Math.abs(lastLocal.lx - target.interior.lx),
+        Math.abs(lastLocal.ly - target.interior.ly),
+      ) <= reach
+    ) {
+      return null;
+    }
+  }
+
+  // BFS over the interior obstacles, treating other NPC tiles as blocked.
+  const occupied = interior.obstacles.slice();
+  // Block other NPC tiles so we don't try to walk through them.
+  // (We don't have full npcs here; the route walker treats live obstacle
+  // collisions as a hard stop separately.)
+  // Find a passable tile within reach of the target that has a path.
+  const tx = target.interior.lx;
+  const ty = target.interior.ly;
+  let bestPath: Array<{ px: number; py: number }> | null = null;
+  for (let r = 1; r <= reach && !bestPath; r++) {
+    for (let dy = -r; dy <= r; dy++) {
+      for (let dx = -r; dx <= r; dx++) {
+        if (Math.abs(dx) !== r && Math.abs(dy) !== r) continue;
+        const lx = tx + dx;
+        const ly = ty + dy;
+        if (lx < 0 || ly < 0 || lx >= INTERIOR_W || ly >= INTERIOR_H) continue;
+        if (isLocalObstacle(interior, lx, ly)) continue;
+        const path = bfs(occupied, INTERIOR_W, INTERIOR_H, here.lx, here.ly, lx, ly);
+        if (!path) continue;
+        if (!bestPath || path.length < bestPath.length) bestPath = path;
+      }
+    }
+  }
+  if (!bestPath) return null;
+  const route = bestPath.map((p) => {
+    const g = localToGlobal(here.rx, here.ry, p.px, p.py);
+    return { gx: g.gx, gy: g.gy };
+  });
+  return {
+    ...player,
+    route: route.length === 0 ? null : route,
+    stepCooldown: route.length === 0 ? 0 : Math.max(1, player.stats.speed),
+  };
+}
+
 function tryCollect(
   player: Player,
   interiors: Record<string, BiomeInterior>,
@@ -215,6 +327,7 @@ function pickupLoot(
   interiors: Record<string, BiomeInterior>,
   inventory: Inventory,
 ): {
+  player: Player;
   interiors: Record<string, BiomeInterior>;
   inventory: Inventory;
   pickups: PickupNotice[];
@@ -222,9 +335,9 @@ function pickupLoot(
   const { rx, ry, lx, ly } = globalToLocal(player.gx, player.gy);
   const k = regionKey(rx, ry);
   const interior = interiors[k];
-  if (!interior) return { interiors, inventory, pickups: [] };
+  if (!interior) return { player, interiors, inventory, pickups: [] };
   const pile = lootAtLocal(interior, lx, ly);
-  if (!pile) return { interiors, inventory, pickups: [] };
+  if (!pile) return { player, interiors, inventory, pickups: [] };
   const nextInventory: Inventory = { ...inventory };
   const pickups: PickupNotice[] = [];
   for (const key of Object.keys(pile.items) as ResourceKind[]) {
@@ -233,7 +346,12 @@ function pickupLoot(
     nextInventory[key] = (nextInventory[key] ?? 0) + amt;
     pickups.push({ kind: key, amount: amt });
   }
+  let nextPlayer = player;
+  if (pile.weapons && pile.weapons.length > 0) {
+    nextPlayer = { ...player, weapons: [...player.weapons, ...pile.weapons] };
+  }
   return {
+    player: nextPlayer,
     interiors: { ...interiors, [k]: removeLoot(interior, pile.id) },
     inventory: nextInventory,
     pickups,

--- a/lib/sim/player.ts
+++ b/lib/sim/player.ts
@@ -1,9 +1,16 @@
+import type { WeaponInstance } from "@/lib/sim/weapons";
+
 export type PlayerStats = {
   speed: number;
   perception: number;
+  attack: number;
+  defense: number;
+  reach: number;
 };
 
-export type PendingAction = { kind: "collect"; resourceId: string };
+export type PendingAction =
+  | { kind: "collect"; resourceId: string }
+  | { kind: "attack"; npcId: string };
 
 export type Player = {
   gx: number;
@@ -15,6 +22,8 @@ export type Player = {
   healthMax: number;
   starveAccum: number;
   stats: PlayerStats;
+  weapons: WeaponInstance[];
+  combatCooldown: number;
   route: Array<{ gx: number; gy: number }> | null;
   stepCooldown: number;
   pendingAction: PendingAction | null;
@@ -24,6 +33,9 @@ export const ENERGY_MAX = 10;
 export const HEALTH_MAX = 10;
 export const BASE_SPEED_TICKS_PER_TILE = 2;
 export const BASE_PERCEPTION = 6;
+export const BASE_ATTACK = 1;
+export const BASE_DEFENSE = 0;
+export const BASE_REACH = 1;
 
 export const WALK_ENERGY_PER_STEP = 0.4;
 export const STARVE_TICKS_PER_DAMAGE = 80;
@@ -40,7 +52,15 @@ export function createPlayer(spawn: { gx: number; gy: number }): Player {
     health: HEALTH_MAX,
     healthMax: HEALTH_MAX,
     starveAccum: 0,
-    stats: { speed: BASE_SPEED_TICKS_PER_TILE, perception: BASE_PERCEPTION },
+    stats: {
+      speed: BASE_SPEED_TICKS_PER_TILE,
+      perception: BASE_PERCEPTION,
+      attack: BASE_ATTACK,
+      defense: BASE_DEFENSE,
+      reach: BASE_REACH,
+    },
+    weapons: [],
+    combatCooldown: 0,
     route: null,
     stepCooldown: 0,
     pendingAction: null,

--- a/lib/sim/player.ts
+++ b/lib/sim/player.ts
@@ -37,7 +37,7 @@ export const BASE_ATTACK = 1;
 export const BASE_DEFENSE = 0;
 export const BASE_REACH = 1;
 
-export const WALK_ENERGY_PER_STEP = 0.4;
+export const WALK_ENERGY_PER_STEP = 0.3;
 export const STARVE_TICKS_PER_DAMAGE = 80;
 export const EAT_ENERGY_PER_FOOD = 3;
 export const EAT_HEALTH_PER_FOOD = 1;

--- a/lib/sim/weapons.ts
+++ b/lib/sim/weapons.ts
@@ -1,0 +1,82 @@
+import type { Inventory } from "@/lib/sim/inventory";
+import { WEAPONS, type WeaponKind } from "@/content/weapons";
+
+export type WeaponInstance = {
+  kind: WeaponKind;
+  usesLeft: number;
+};
+
+export function affordable(inventory: Inventory, kind: WeaponKind): boolean {
+  const recipe = WEAPONS[kind].recipe;
+  for (const k of Object.keys(recipe) as Array<keyof typeof recipe>) {
+    const need = recipe[k] ?? 0;
+    const have = inventory[k] ?? 0;
+    if (have < need) return false;
+  }
+  return true;
+}
+
+export function spendRecipe(
+  inventory: Inventory,
+  kind: WeaponKind,
+): Inventory | null {
+  if (!affordable(inventory, kind)) return null;
+  const recipe = WEAPONS[kind].recipe;
+  const next: Inventory = { ...inventory };
+  for (const k of Object.keys(recipe) as Array<keyof typeof recipe>) {
+    const need = recipe[k] ?? 0;
+    const have = next[k] ?? 0;
+    next[k] = have - need;
+  }
+  return next;
+}
+
+export function makeWeapon(kind: WeaponKind): WeaponInstance {
+  return { kind, usesLeft: WEAPONS[kind].durability };
+}
+
+// Pick the highest-attack weapon whose reach covers `distance`. Returns null
+// if no weapon (caller should fall back to bare hands).
+export function pickWeaponForRange(
+  weapons: WeaponInstance[],
+  distance: number,
+): WeaponInstance | null {
+  let best: WeaponInstance | null = null;
+  let bestAttack = -1;
+  for (const w of weapons) {
+    if (w.usesLeft <= 0) continue;
+    const meta = WEAPONS[w.kind];
+    if (meta.reach < distance) continue;
+    if (meta.attack > bestAttack) {
+      best = w;
+      bestAttack = meta.attack;
+    }
+  }
+  return best;
+}
+
+export function consumeUse(
+  weapons: WeaponInstance[],
+  kind: WeaponKind,
+): WeaponInstance[] {
+  let consumed = false;
+  const out: WeaponInstance[] = [];
+  for (const w of weapons) {
+    if (!consumed && w.kind === kind && w.usesLeft > 0) {
+      consumed = true;
+      const next = w.usesLeft - 1;
+      if (next > 0) out.push({ kind: w.kind, usesLeft: next });
+      continue;
+    }
+    out.push(w);
+  }
+  return out;
+}
+
+export function weaponAttackBonus(weapon: WeaponInstance | null): number {
+  return weapon ? WEAPONS[weapon.kind].attack : 0;
+}
+
+export function weaponReach(weapon: WeaponInstance | null): number {
+  return weapon ? WEAPONS[weapon.kind].reach : 1;
+}

--- a/lib/sim/world.ts
+++ b/lib/sim/world.ts
@@ -40,6 +40,13 @@ export type GameOverReason =
   | "starved"
   | { kind: "killed"; killerNpcId: string; killerName: string; factionId: string };
 
+export type PickupNotice = {
+  id: string;
+  tick: number;
+  kind: import("@/content/resources").ResourceKind;
+  amount: number;
+};
+
 export type World = {
   version: number;
   seed: number;
@@ -63,6 +70,10 @@ export type World = {
   playerReputation: Record<string, number>;
   // pairKey(a,b) -> faction-vs-faction relation. Negative = hostile.
   factionRelations: Record<string, number>;
+  // Ring buffer of recent player pickups (resources + loot). Ephemeral —
+  // BiomeScene drains them to spawn floating text and they fall off after
+  // a short window.
+  recentPickups: PickupNotice[];
   gameOver: boolean;
   gameOverReason: GameOverReason | null;
 };
@@ -88,6 +99,7 @@ export function createWorld(seed = Date.now() & 0xffffffff): World {
     discoveredRegions: {},
     playerReputation: {},
     factionRelations: {},
+    recentPickups: [],
     gameOver: false,
     gameOverReason: null,
   };
@@ -158,6 +170,7 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
   let factions = world.factions;
   let factionRelations = world.factionRelations;
   let playerReputation = world.playerReputation;
+  let recentPickups = prunePickups(world.recentPickups, ticks);
   let gameOver: boolean = world.gameOver;
   let gameOverReason: GameOverReason | null = world.gameOverReason;
   let discoveredRegions = world.discoveredRegions;
@@ -170,12 +183,28 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
       npcs,
       playerReputation,
       rng,
+      ticks,
     });
     player = stepped.player;
     interiors = stepped.interiors;
     inventory = stepped.inventory;
     npcs = stepped.npcs;
     playerReputation = stepped.playerReputation;
+    if (stepped.pickups.length > 0) {
+      let next = recentPickups;
+      for (const p of stepped.pickups) {
+        next = [
+          ...next,
+          {
+            id: `pkp-${ticks}-${next.length}`,
+            tick: ticks,
+            kind: p.kind,
+            amount: p.amount,
+          },
+        ];
+      }
+      recentPickups = next.slice(-12);
+    }
     if (stepped.death) {
       gameOver = true;
       gameOverReason = "starved";
@@ -246,6 +275,7 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
     factions,
     factionRelations,
     playerReputation,
+    recentPickups,
     gameOver,
     gameOverReason,
   };
@@ -342,6 +372,16 @@ function detectEncounter(
     return buildEncounterEvent(world, next, faction, rng);
   }
   return null;
+}
+
+// Pickups are short-lived (UI hints). After ~10 ticks (~2.5s at 1x), drop.
+const PICKUP_TTL_TICKS = 10;
+function prunePickups(prev: PickupNotice[], ticks: number): PickupNotice[] {
+  const out: PickupNotice[] = [];
+  for (const p of prev) {
+    if (ticks - p.tick <= PICKUP_TTL_TICKS) out.push(p);
+  }
+  return out;
 }
 
 function ensureNeighbors(

--- a/lib/sim/world.ts
+++ b/lib/sim/world.ts
@@ -171,6 +171,7 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
   let factionRelations = world.factionRelations;
   let playerReputation = world.playerReputation;
   let recentPickups = prunePickups(world.recentPickups, ticks);
+  const combatDeathEvents: WorldEvent[] = [];
   let gameOver: boolean = world.gameOver;
   let gameOverReason: GameOverReason | null = world.gameOverReason;
   let discoveredRegions = world.discoveredRegions;
@@ -208,7 +209,16 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
     if (stepped.death) {
       gameOver = true;
       gameOverReason = "starved";
-      player = { ...player, route: null, pendingAction: null, stepCooldown: 0 };
+      const dropped = dropDeathLoot(player, inventory, interiors, ticks);
+      interiors = dropped.interiors;
+      inventory = {};
+      player = {
+        ...player,
+        weapons: [],
+        route: null,
+        pendingAction: null,
+        stepCooldown: 0,
+      };
     }
 
     const cur = globalToLocal(player.gx, player.gy);
@@ -230,6 +240,7 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
         playerReputation,
         mapW: MAP_W,
         mapH: MAP_H,
+        ticks,
       },
       rng,
     );
@@ -247,7 +258,29 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
         killerName: combat.playerKilledBy.name,
         factionId: combat.playerKilledBy.factionId,
       };
-      player = { ...player, route: null, pendingAction: null, stepCooldown: 0 };
+      const dropped = dropDeathLoot(player, inventory, interiors, ticks);
+      interiors = dropped.interiors;
+      inventory = {};
+      player = {
+        ...player,
+        weapons: [],
+        route: null,
+        pendingAction: null,
+        stepCooldown: 0,
+      };
+    }
+    // Build combat-death events to splice into the feed below.
+    for (const d of combat.deaths) {
+      const killer = d.killerName ? `${d.killerName} ` : "";
+      combatDeathEvents.push({
+        id: `kill-${ticks}-${d.npcId}`,
+        tick: ticks,
+        topic: d.killerKind === "player" ? "combat:player-kill" : "combat:npc-kill",
+        context:
+          d.killerKind === "player"
+            ? `You killed ${d.name}.`
+            : `${killer}killed ${d.name}.`,
+      });
     }
     // Remove dead NPCs from the canonical list.
     npcs = npcs.filter((n) => n.combatHealth > 0);
@@ -261,6 +294,10 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
   const regionPresence = built.presence;
   const regionControl = built.control;
 
+  const startingEvents =
+    combatDeathEvents.length > 0
+      ? [...combatDeathEvents, ...world.recentEvents].slice(0, 8)
+      : world.recentEvents;
   const next: World = {
     ...world,
     ticks,
@@ -276,6 +313,7 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
     factionRelations,
     playerReputation,
     recentPickups,
+    recentEvents: startingEvents,
     gameOver,
     gameOverReason,
   };
@@ -372,6 +410,35 @@ function detectEncounter(
     return buildEncounterEvent(world, next, faction, rng);
   }
   return null;
+}
+
+function dropDeathLoot(
+  player: Player,
+  inventory: Inventory,
+  interiors: Record<string, BiomeInterior>,
+  ticks: number,
+): { interiors: Record<string, BiomeInterior> } {
+  const { rx, ry, lx, ly } = globalToLocal(player.gx, player.gy);
+  const k = regionKey(rx, ry);
+  const interior = interiors[k];
+  if (!interior) return { interiors };
+  const items: Inventory = {};
+  for (const key of Object.keys(inventory) as Array<keyof Inventory>) {
+    const v = inventory[key] ?? 0;
+    if (v > 0) items[key] = v;
+  }
+  const weapons = player.weapons.length > 0 ? [...player.weapons] : undefined;
+  if (Object.keys(items).length === 0 && !weapons) return { interiors };
+  const pile = {
+    id: `grave-${ticks}-${rx}-${ry}-${lx}-${ly}`,
+    lx,
+    ly,
+    items,
+    weapons,
+    fromDeath: true,
+  };
+  const next = { ...interior, loot: [...interior.loot, pile] };
+  return { interiors: { ...interiors, [k]: next } };
 }
 
 // Pickups are short-lived (UI hints). After ~10 ticks (~2.5s at 1x), drop.

--- a/lib/sim/world.ts
+++ b/lib/sim/world.ts
@@ -19,10 +19,11 @@ import { createPlayer } from "@/lib/sim/player";
 import { tickPlayer } from "@/lib/sim/player-tick";
 import type { Inventory } from "@/lib/sim/inventory";
 import { biomeAt, isPassable, type Biome } from "@/lib/sim/biome";
+import { tickCombat } from "@/lib/sim/combat";
 
 export { biomeAt, isPassable, type Biome } from "@/lib/sim/biome";
 
-export const WORLD_VERSION = 6;
+export const WORLD_VERSION = 7;
 export const MAP_W = 32;
 export const MAP_H = 32;
 export const NPC_COUNT = 200;
@@ -34,6 +35,10 @@ const CONTROL_DECAY_EVERY = 16;
 const CONTROL_DECAY_FACTOR = 0.85;
 const CONTROL_THRESHOLD = 5;
 const CONTROL_DROP_BELOW = 0.5;
+
+export type GameOverReason =
+  | "starved"
+  | { kind: "killed"; killerNpcId: string; killerName: string; factionId: string };
 
 export type World = {
   version: number;
@@ -54,7 +59,12 @@ export type World = {
   // Set as the player visits regions. Phase 4 reads this for fog-of-war
   // on the world map; for Phase 1 it's just bookkeeping.
   discoveredRegions: Record<string, true>;
+  // factionId -> per-player reputation. Drives hostile/friendly encounters.
+  playerReputation: Record<string, number>;
+  // pairKey(a,b) -> faction-vs-faction relation. Negative = hostile.
+  factionRelations: Record<string, number>;
   gameOver: boolean;
+  gameOverReason: GameOverReason | null;
 };
 
 export function createWorld(seed = Date.now() & 0xffffffff): World {
@@ -76,7 +86,10 @@ export function createWorld(seed = Date.now() & 0xffffffff): World {
     regionPresence: {},
     regionControl: {},
     discoveredRegions: {},
+    playerReputation: {},
+    factionRelations: {},
     gameOver: false,
+    gameOverReason: null,
   };
 }
 
@@ -127,29 +140,45 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
   if (world.gameOver) return { world, event: null };
 
   const rng = createRng(world.rngState);
+  const playerRegion = world.player ? globalToLocal(world.player.gx, world.player.gy) : null;
   const tickCtx = {
     rng,
     mapW: MAP_W,
     mapH: MAP_H,
     regionControl: world.regionControl,
     npcs: world.npcs,
+    playerRegion: playerRegion ? { rx: playerRegion.rx, ry: playerRegion.ry } : null,
   };
-  const npcs = world.npcs.map((n) => tickNpc(n, tickCtx));
+  let npcs = world.npcs.map((n) => tickNpc(n, tickCtx));
   const ticks = world.ticks + 1;
 
   let player = world.player;
   let interiors = world.biomeInteriors;
   let inventory = world.inventory;
+  let factions = world.factions;
+  let factionRelations = world.factionRelations;
+  let playerReputation = world.playerReputation;
   let gameOver: boolean = world.gameOver;
+  let gameOverReason: GameOverReason | null = world.gameOverReason;
   let discoveredRegions = world.discoveredRegions;
 
   if (player) {
-    const stepped = tickPlayer({ player, interiors, inventory });
+    const stepped = tickPlayer({
+      player,
+      interiors,
+      inventory,
+      npcs,
+      playerReputation,
+      rng,
+    });
     player = stepped.player;
     interiors = stepped.interiors;
     inventory = stepped.inventory;
+    npcs = stepped.npcs;
+    playerReputation = stepped.playerReputation;
     if (stepped.death) {
       gameOver = true;
+      gameOverReason = "starved";
       player = { ...player, route: null, pendingAction: null, stepCooldown: 0 };
     }
 
@@ -159,6 +188,40 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
       discoveredRegions = { ...discoveredRegions, [key]: true as const };
     }
     interiors = ensureNeighbors(interiors, world.seed, cur.rx, cur.ry);
+  }
+
+  if (!gameOver) {
+    const combat = tickCombat(
+      {
+        npcs,
+        player,
+        interiors,
+        factions,
+        factionRelations,
+        playerReputation,
+        mapW: MAP_W,
+        mapH: MAP_H,
+      },
+      rng,
+    );
+    npcs = combat.npcs;
+    player = combat.player;
+    interiors = combat.interiors;
+    factions = combat.factions;
+    factionRelations = combat.factionRelations;
+    playerReputation = combat.playerReputation;
+    if (combat.playerKilledBy && player && player.health <= 0) {
+      gameOver = true;
+      gameOverReason = {
+        kind: "killed",
+        killerNpcId: combat.playerKilledBy.npcId,
+        killerName: combat.playerKilledBy.name,
+        factionId: combat.playerKilledBy.factionId,
+      };
+      player = { ...player, route: null, pendingAction: null, stepCooldown: 0 };
+    }
+    // Remove dead NPCs from the canonical list.
+    npcs = npcs.filter((n) => n.combatHealth > 0);
   }
 
   const built = updatePresence(
@@ -180,13 +243,17 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
     regionPresence,
     regionControl,
     discoveredRegions,
+    factions,
+    factionRelations,
+    playerReputation,
     gameOver,
+    gameOverReason,
   };
 
   let encounter: WorldEvent | null = null;
   if (player) {
-    const playerRegion = globalToLocal(player.gx, player.gy);
-    encounter = detectEncounter(world.npcs, npcs, next, playerRegion, rng);
+    const region = globalToLocal(player.gx, player.gy);
+    encounter = detectEncounter(world.npcs, npcs, next, region, rng);
     if (encounter) {
       next.recentEvents = [encounter, ...next.recentEvents].slice(0, 8);
       next.rngState = rng.state();
@@ -263,9 +330,10 @@ function detectEncounter(
   playerRegion: { rx: number; ry: number; lx: number; ly: number },
   rng: import("@/lib/sim/rng").Rng,
 ): WorldEvent | null {
-  for (let i = 0; i < nextNpcs.length; i++) {
-    const next = nextNpcs[i]!;
-    const prev = prevNpcs[i];
+  const prevById = new Map<string, Npc>();
+  for (const p of prevNpcs) prevById.set(p.id, p);
+  for (const next of nextNpcs) {
+    const prev = prevById.get(next.id);
     if (!prev) continue;
     if (prev.rx === next.rx && prev.ry === next.ry) continue;
     if (next.rx !== playerRegion.rx || next.ry !== playerRegion.ry) continue;

--- a/lib/state/game-store.ts
+++ b/lib/state/game-store.ts
@@ -26,6 +26,7 @@ import {
 } from "@/lib/sim/biome-interior";
 import { bfsPredicate } from "@/lib/sim/path";
 import type { PendingAction, Player } from "@/lib/sim/player";
+import { createPlayer } from "@/lib/sim/player";
 import { setPendingAttack } from "@/lib/sim/player-tick";
 import {
   affordable,
@@ -267,16 +268,51 @@ export const useGameStore = create<GameStore>((set, get) => ({
   },
 
   resetAfterDeath: () => {
+    const current = get().world;
+    if (!current) return;
+    // Respawn into the same world: keep NPCs, factions, regions, faction
+    // relations, and any death loot we just dropped. Only the player and
+    // the run-specific UI flags reset. If the player never settled a home
+    // we can't respawn — fall back to a fresh world (treat it like a new game).
+    if (!current.home) {
+      set({
+        world: createWorld(),
+        selectedNpcId: null,
+        selectedRegion: null,
+        lastEvent: null,
+        paused: false,
+        view: "world",
+        homePending: true,
+        inventoryOpen: false,
+        tutorialOpen: false,
+        npcContextMenu: null,
+      });
+      return;
+    }
+    const center = regionCenterGlobal(current.home.rx, current.home.ry);
+    const seeded = ensureInteriorsForRegion(current, current.home.rx, current.home.ry);
+    const interior = seeded.biomeInteriors[regionKey(current.home.rx, current.home.ry)];
+    const spawn = interior
+      ? nearestPassable(interior, center.gx, center.gy, current.home.rx, current.home.ry)
+      : center;
+    const fresh = createPlayer(spawn);
     set({
-      world: createWorld(),
+      world: {
+        ...seeded,
+        player: fresh,
+        gameOver: false,
+        gameOverReason: null,
+        recentPickups: [],
+      },
       selectedNpcId: null,
       selectedRegion: null,
       lastEvent: null,
       paused: false,
-      view: "world",
-      homePending: true,
+      view: "biome",
+      homePending: false,
       inventoryOpen: false,
       tutorialOpen: false,
+      npcContextMenu: null,
     });
   },
 

--- a/lib/state/game-store.ts
+++ b/lib/state/game-store.ts
@@ -14,7 +14,7 @@ import {
 import { loadWorld, saveWorld } from "@/lib/save/db";
 import { bus } from "@/lib/render/bus";
 import type { WorldEvent } from "@/lib/sim/events";
-import { gainRep } from "@/lib/sim/faction";
+import { gainPlayerRep } from "@/lib/sim/faction";
 import {
   globalToLocal,
   isLocalObstacle,
@@ -26,6 +26,13 @@ import {
 } from "@/lib/sim/biome-interior";
 import { bfsPredicate } from "@/lib/sim/path";
 import type { PendingAction, Player } from "@/lib/sim/player";
+import { setPendingAttack } from "@/lib/sim/player-tick";
+import {
+  affordable,
+  makeWeapon,
+  spendRecipe,
+} from "@/lib/sim/weapons";
+import type { WeaponKind } from "@/content/weapons";
 
 const AUTOSAVE_EVERY_TICKS = 60;
 export const WALK_MAX_RADIUS = 80;
@@ -61,6 +68,9 @@ type GameStore = {
 
   acceptEncounter: () => void;
   dismissEncounter: () => void;
+
+  craft: (kind: WeaponKind) => boolean;
+  attackNpc: (id: string) => void;
 };
 
 export const useGameStore = create<GameStore>((set, get) => ({
@@ -254,9 +264,31 @@ export const useGameStore = create<GameStore>((set, get) => ({
       const prev = inventory[enc.offer.kind] ?? 0;
       inventory = { ...inventory, [enc.offer.kind]: prev + enc.offer.amount };
     }
-    const factions = gainRep(current.factions, enc.factionId, 2);
-    set({ world: { ...current, inventory, factions }, lastEvent: null });
+    const playerReputation = gainPlayerRep(current.playerReputation, enc.factionId, 2);
+    set({ world: { ...current, inventory, playerReputation }, lastEvent: null });
   },
 
   dismissEncounter: () => set({ lastEvent: null }),
+
+  craft: (kind) => {
+    const current = get().world;
+    if (!current?.player) return false;
+    if (!affordable(current.inventory, kind)) return false;
+    const nextInventory = spendRecipe(current.inventory, kind);
+    if (!nextInventory) return false;
+    const weapon = makeWeapon(kind);
+    const player: Player = {
+      ...current.player,
+      weapons: [...current.player.weapons, weapon],
+    };
+    set({ world: { ...current, inventory: nextInventory, player } });
+    return true;
+  },
+
+  attackNpc: (id) => {
+    const current = get().world;
+    if (!current?.player || current.gameOver) return;
+    const player = setPendingAttack(current.player, id);
+    set({ world: { ...current, player } });
+  },
 }));

--- a/lib/state/game-store.ts
+++ b/lib/state/game-store.ts
@@ -49,6 +49,9 @@ type GameStore = {
   lastEvent: WorldEvent | null;
   view: View;
   homePending: boolean;
+  inventoryOpen: boolean;
+  tutorialOpen: boolean;
+  debugMode: boolean;
 
   startNew: () => void;
   loadFromDisk: (slot: string) => Promise<void>;
@@ -71,6 +74,14 @@ type GameStore = {
 
   craft: (kind: WeaponKind) => boolean;
   attackNpc: (id: string) => void;
+
+  openInventory: () => void;
+  closeInventory: () => void;
+  openTutorial: () => void;
+  closeTutorial: () => void;
+  toggleDebug: () => void;
+  teleportToRegion: (rx: number, ry: number) => void;
+  inspectBiome: (rx: number, ry: number) => void;
 };
 
 export const useGameStore = create<GameStore>((set, get) => ({
@@ -82,6 +93,9 @@ export const useGameStore = create<GameStore>((set, get) => ({
   lastEvent: null,
   view: "world",
   homePending: false,
+  inventoryOpen: false,
+  tutorialOpen: false,
+  debugMode: false,
 
   startNew: () => {
     set({
@@ -92,6 +106,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
       paused: false,
       view: "world",
       homePending: true,
+      inventoryOpen: false,
+      tutorialOpen: true,
     });
   },
 
@@ -244,6 +260,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
       paused: false,
       view: "world",
       homePending: true,
+      inventoryOpen: false,
+      tutorialOpen: false,
     });
   },
 
@@ -291,4 +309,67 @@ export const useGameStore = create<GameStore>((set, get) => ({
     const player = setPendingAttack(current.player, id);
     set({ world: { ...current, player } });
   },
+
+  openInventory: () =>
+    set({
+      inventoryOpen: true,
+      selectedNpcId: null,
+      selectedRegion: null,
+    }),
+  closeInventory: () => set({ inventoryOpen: false }),
+  openTutorial: () => set({ tutorialOpen: true }),
+  closeTutorial: () => set({ tutorialOpen: false }),
+  toggleDebug: () => set({ debugMode: !get().debugMode }),
+
+  teleportToRegion: (rx, ry) => {
+    const current = get().world;
+    if (!current?.player || current.gameOver) return;
+    const center = regionCenterGlobal(rx, ry);
+    const seeded = ensureInteriorsForRegion(current, rx, ry);
+    const interior = seeded.biomeInteriors[regionKey(rx, ry)];
+    if (!interior) return;
+    const target = nearestPassable(interior, center.gx, center.gy, rx, ry);
+    const player: Player = {
+      ...seeded.player!,
+      gx: target.gx,
+      gy: target.gy,
+      route: null,
+      stepCooldown: 0,
+      pendingAction: null,
+    };
+    set({
+      world: { ...seeded, player },
+      view: "biome",
+      selectedNpcId: null,
+      selectedRegion: null,
+    });
+    bus.emit("npc:deselected");
+  },
+
+  inspectBiome: (rx, ry) => {
+    get().teleportToRegion(rx, ry);
+  },
 }));
+
+function nearestPassable(
+  interior: import("@/lib/sim/biome-interior").BiomeInterior,
+  gx: number,
+  gy: number,
+  rx: number,
+  ry: number,
+): { gx: number; gy: number } {
+  for (let r = 0; r <= 8; r++) {
+    for (let dy = -r; dy <= r; dy++) {
+      for (let dx = -r; dx <= r; dx++) {
+        if (Math.abs(dx) !== r && Math.abs(dy) !== r) continue;
+        const tgx = gx + dx;
+        const tgy = gy + dy;
+        const lx = tgx - rx * INTERIOR_W;
+        const ly = tgy - ry * INTERIOR_H;
+        if (lx < 0 || ly < 0 || lx >= INTERIOR_W || ly >= INTERIOR_H) continue;
+        if (!isLocalObstacle(interior, lx, ly)) return { gx: tgx, gy: tgy };
+      }
+    }
+  }
+  return { gx, gy };
+}

--- a/lib/state/game-store.ts
+++ b/lib/state/game-store.ts
@@ -57,6 +57,7 @@ type GameStore = {
   tutorialOpen: boolean;
   debugMode: boolean;
   debugMinimized: boolean;
+  mapShowFactions: boolean;
   npcContextMenu: NpcContextMenu | null;
 
   startNew: () => void;
@@ -87,6 +88,7 @@ type GameStore = {
   closeTutorial: () => void;
   toggleDebug: () => void;
   toggleDebugMinimized: () => void;
+  toggleMapFactions: () => void;
   openNpcContextMenu: (id: string, x: number, y: number) => void;
   closeNpcContextMenu: () => void;
   eatFood: (kind: import("@/content/resources").ResourceKind) => void;
@@ -107,6 +109,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
   tutorialOpen: false,
   debugMode: false,
   debugMinimized: false,
+  mapShowFactions: true,
   npcContextMenu: null,
 
   startNew: () => {
@@ -333,6 +336,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
   closeTutorial: () => set({ tutorialOpen: false }),
   toggleDebug: () => set({ debugMode: !get().debugMode }),
   toggleDebugMinimized: () => set({ debugMinimized: !get().debugMinimized }),
+  toggleMapFactions: () => set({ mapShowFactions: !get().mapShowFactions }),
 
   openNpcContextMenu: (id, x, y) =>
     set({

--- a/lib/state/game-store.ts
+++ b/lib/state/game-store.ts
@@ -33,12 +33,16 @@ import {
   spendRecipe,
 } from "@/lib/sim/weapons";
 import type { WeaponKind } from "@/content/weapons";
+import { RESOURCES, type ResourceKind } from "@/content/resources";
+import { EAT_ENERGY_PER_FOOD, EAT_HEALTH_PER_FOOD } from "@/lib/sim/player";
 
 const AUTOSAVE_EVERY_TICKS = 60;
 export const WALK_MAX_RADIUS = 80;
 
 export type SelectedRegion = { rx: number; ry: number };
 export type View = "world" | "biome";
+
+export type NpcContextMenu = { id: string; x: number; y: number };
 
 type GameStore = {
   world: World | null;
@@ -52,6 +56,8 @@ type GameStore = {
   inventoryOpen: boolean;
   tutorialOpen: boolean;
   debugMode: boolean;
+  debugMinimized: boolean;
+  npcContextMenu: NpcContextMenu | null;
 
   startNew: () => void;
   loadFromDisk: (slot: string) => Promise<void>;
@@ -80,6 +86,10 @@ type GameStore = {
   openTutorial: () => void;
   closeTutorial: () => void;
   toggleDebug: () => void;
+  toggleDebugMinimized: () => void;
+  openNpcContextMenu: (id: string, x: number, y: number) => void;
+  closeNpcContextMenu: () => void;
+  eatFood: (kind: import("@/content/resources").ResourceKind) => void;
   teleportToRegion: (rx: number, ry: number) => void;
   inspectBiome: (rx: number, ry: number) => void;
 };
@@ -96,6 +106,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
   inventoryOpen: false,
   tutorialOpen: false,
   debugMode: false,
+  debugMinimized: false,
+  npcContextMenu: null,
 
   startNew: () => {
     set({
@@ -320,6 +332,30 @@ export const useGameStore = create<GameStore>((set, get) => ({
   openTutorial: () => set({ tutorialOpen: true }),
   closeTutorial: () => set({ tutorialOpen: false }),
   toggleDebug: () => set({ debugMode: !get().debugMode }),
+  toggleDebugMinimized: () => set({ debugMinimized: !get().debugMinimized }),
+
+  openNpcContextMenu: (id, x, y) =>
+    set({
+      npcContextMenu: { id, x, y },
+      selectedNpcId: null,
+      selectedRegion: null,
+    }),
+  closeNpcContextMenu: () => set({ npcContextMenu: null }),
+
+  eatFood: (kind: ResourceKind) => {
+    const current = get().world;
+    if (!current?.player || current.gameOver) return;
+    if (!RESOURCES[kind].food) return;
+    const have = current.inventory[kind] ?? 0;
+    if (have <= 0) return;
+    const inventory = { ...current.inventory, [kind]: have - 1 };
+    const player: Player = {
+      ...current.player,
+      energy: Math.min(current.player.energyMax, current.player.energy + EAT_ENERGY_PER_FOOD),
+      health: Math.min(current.player.healthMax, current.player.health + EAT_HEALTH_PER_FOOD),
+    };
+    set({ world: { ...current, inventory, player } });
+  },
 
   teleportToRegion: (rx, ry) => {
     const current = get().world;


### PR DESCRIPTION
Tracks #13. First half of Phase 3 — the sim foundations and player-driven combat. Phase 3b (hostile chase toward player, friendly flee, ranged sling, encounter UI polish) is a follow-up branch off this one.

## Summary

- NPCs entering the player's region now move tile-by-tile through the biome interior toward goal-flavoured destinations (raid → nearest hostile-faction NPC, gather → resource tile, otherwise wander), pathfinding around obstacles via BFS.
- Tile-level hostile pairs in the player's interior trade blows with floating damage numbers and hit flashes — faction skirmishes are visible.
- Off-screen hostile pairs resolve abstractly each tick, swinging faction power and souring inter-faction relations as kills accumulate. The world fights without you.
- Weapons (stick / club / sling) craft from foraged materials. Implicit equip picks the highest-attack weapon whose reach covers the target; durability drains per hit.
- Per-player reputation drives encounter sentiment and NPC hostility toward the player. Friendly gifts now grant per-player rep instead of world rep.
- Game-over distinguishes "Starved" from "Killed by {name} of {faction}".
- HUD gains a pulsing combat dot inside the health pill when a hostile is in your region; NpcPanel surfaces stance + combat stats + predicted damage.
- Bumps `WORLD_VERSION` 6 → 7. Old saves regenerate via the existing version-mismatch path.

## Follow-up commit (`0e1b443`)
- Attack button shows for any non-friendly stance (was unreachable behind 0-rep "wary" gate).
- Interior NPC wander no longer freezes — cached `tileIntent` re-rolls on arrival.
- Pickup toast (`+1 Wood`) for resources and loot.
- Crafting moved into a new InventoryPanel reachable from the inventory pill.
- New-game tutorial modal walks through the core mechanics.
- Debug mode toggle (bug icon) — overlay shows `npcs.length` / ticks / player coords / per-faction stats; debug RegionPanel adds Teleport + Inspect biome.

## Test plan

Open the Vercel preview URL on a phone. Ignore the `claude/add-inventory-system-7fHmU` branch reference in the chat history — this PR's branch is `claude/phase-3-combat`.

### 1. New game and tutorial
- [x] Start a fresh run from `/`. The 7-page tutorial modal appears.
- [x] Each Next button advances; Back returns; Skip dismisses immediately.
- [x] Final page button reads "Begin"; tapping it dismisses the modal and you can interact with the world map.

### 2. HUD primitives
- [x] Top-left: home button, top-pill: tick counter, pause, speed cycle (1×→2×→4×), home/biome view toggle, and a debug bug icon.
- [x] Tap the debug bug. A small overlay appears on the left with `npcs`, `tick`, `player`, `in-region`, and per-faction `pwr`/`rep`.
- [x] Tap the bug again to hide.
- [x] Top-right: pills for health, energy, and inventory. Inventory pill says "Inventory" before the first pickup; once you've collected anything, it shows colored dots + counts.

### 3. Home base + foraging + pickup feedback
- [x] Claim a region with forest or stone nearby.
- [x] Walk onto a coloured resource dot. A floating `+1 {Name}` toast appears at your tile in the resource's color.
- [x] Open the inventory pill. The "Materials & food" grid shows what you carry with full labels (Wood, Berry, etc.).
- [x] The Crafting section lists Stick / Club / Sling with full recipe names + counts (e.g. `Wood 0/1`). Tap an unaffordable recipe — button is disabled. Once affordable, tap → weapon appears in the new "Weapons" section with its `usesLeft/durability`.

### 4. Player vs NPC combat
- [x] Wait for an NPC to enter your region. Tap them — NpcPanel opens with Stance (initially "Wary"), Combat stats (`atk N · def N · hp N/M`), and a "Your hit" line predicting damage with your current weapon.
- [x] Tap **Attack**. Player walks/strikes the NPC (within reach). A `-N` damage number floats above them; they flash white briefly. The combat dot pulses inside your health pill.
- [x] Re-open NpcPanel — Stance has flipped to **Hostile** (rep dropped below 0). Their hp is lower.
- [x] Continue attacking with **bare hands** until you die. The game-over modal reads "Killed by {name}." with a faction-flavoured body line.
- [x] Reset with "Begin a new life". Starve to death (don't eat anything until energy 0, then wait). Modal now reads "You starved." with hunger copy.

### 5. Crafted weapon vs NPC
- [x] New run; settle home; gather wood; craft a Stick from the inventory panel.
- [x] Find a hostile-stance NPC (their faction reputation will be `< 0` after any prior attacks; or pick a fresh NPC and accept that you'll start the fight).
- [x] Tap them → Attack. Predicted damage on NpcPanel should reflect the stick (`+1 atk`). NPC dies faster than bare hands.
- [x] On their death, a small wooden-crate glyph appears on their tile. Walk onto it. A `+1 Stone` (or wood/reed) toast appears and the inventory updates.

### 6. NPC vs NPC tile fights
- [x] In debug mode, find a region with two NPCs from different factions where at least one has the `violence` value (NpcPanel shows it). Travel there or use **Teleport** from RegionPanel.
- [x] Watch them step toward each other through obstacles. When adjacent, damage numbers float over the defender; hit flashes register; the loser dies and a loot crate appears on their tile.

### 7. Interior NPC movement (regression check)
- [x] Pick an NPC currently in your region with a **Wandering** goal (per NpcPanel).
- [x] Watch them for ~30s. They should keep walking around the interior — never freeze in place after the first move (the prior bug).
- [ ] Stand still and observe at least one NPC successfully cross the interior to an edge tile and disappear (region transit). On the world map, their `(rx, ry)` will have advanced one region.

### 8. Off-screen / abstract combat
- [x] Enable debug mode and note `world.npcs` count (starts at 200).
- [ ] Pause briefly to let region presence build, then unpause and let the world run for 2–3 minutes.
- [ ] `npcs.length` should slowly drop as off-screen hostile pairs kill each other; per-faction `pwr` shifts in the debug overlay.
- [ ] `Killed by …` toasts should occasionally appear in the encounter feed for nearby NPC-vs-NPC deaths (capped to a few per minute by design).

### 9. Debug teleport / inspect biome
- [x] In debug mode on the world map, tap a passable region you don't currently stand in. RegionPanel surfaces **Teleport** and **Inspect biome**.
- [x] Tap **Teleport** → camera + view jump to that region's biome with the player on a passable tile.
- [x] Tap **Inspect biome** on a different region → same result. Use this to chase an interesting NPC fight.

### 10. Friendly path (no combat)
- [x] Find an NPC whose Stance is "Friendly" (their faction has positive reputation — after accepting a few gifts).
- [x] Tap them. Attack button is hidden (sentiment === "friendly"). Only Stance/Combat stats render. Close the panel to walk away.

### 11. Build / hygiene
- [x] CI green: `npm run typecheck && npm run lint && npm run build` all pass (verified locally).

### Known gaps (intentional, scoped to 3b)
- Hostile NPCs do **not** chase the player across regions yet — they only fight if they happen to enter your region or you tap Attack first.
- Friendly NPCs do **not** flee when attacked yet.
- Sling fires no projectile graphic; ranged kills work but the dotted-line shot lands in 3b.
- "Stand and fight" CTA on hostile encounters from the world view lands in 3b.

## Out of scope (Phase 3b or later)
- Hostile chase / friendly flee AI
- Ranged sling projectile rendering + line-of-sight
- "Stand and fight" CTA on hostile encounters in world view
- Workbench (Phase 4) — Inventory panel has a "Gear (coming soon)" placeholder

https://claude.ai/code/session_01WaF1GjKeY3nv118Eh5FhrV