### PR TITLE
Phase 3b: hostile chase, friendly flee, ranged sling, stand-and-fight

### DIFF
--- a/components/EncounterToast.tsx
+++ b/components/EncounterToast.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { Check, Sword, X } from "@phosphor-icons/react/dist/ssr";
+import { Check, X } from "@phosphor-icons/react/dist/ssr";
 import { useGameStore } from "@/lib/state/game-store";
 import { FACTIONS } from "@/content/factions";
 import { RESOURCES } from "@/content/resources";
@@ -13,8 +13,6 @@ export default function EncounterToast() {
   const event = useGameStore((s) => s.lastEvent);
   const accept = useGameStore((s) => s.acceptEncounter);
   const dismiss = useGameStore((s) => s.dismissEncounter);
-  const view = useGameStore((s) => s.view);
-  const setView = useGameStore((s) => s.setView);
 
   const encounter = event?.encounter ?? null;
 
@@ -79,26 +77,12 @@ export default function EncounterToast() {
               </button>
             </>
           ) : (
-            <>
-              <button
-                onClick={dismiss}
-                className="tactile inline-flex h-10 items-center gap-1.5 rounded-full border border-[var(--color-border)] px-3 text-sm text-[var(--color-fg)] hover:bg-[var(--color-surface-warm)]"
-              >
-                Stand down
-              </button>
-              {view === "world" && (
-                <button
-                  onClick={() => {
-                    setView("biome");
-                    dismiss();
-                  }}
-                  className="tactile inline-flex h-10 items-center gap-1.5 rounded-full bg-[var(--color-accent)] px-3.5 text-sm font-medium text-[var(--color-bg)] shadow-[0_8px_24px_-12px_rgba(217,104,70,0.5)]"
-                >
-                  <Sword size={14} weight="fill" />
-                  Stand and fight
-                </button>
-              )}
-            </>
+            <button
+              onClick={dismiss}
+              className="tactile inline-flex h-10 items-center gap-1.5 rounded-full border border-[var(--color-border)] px-3 text-sm text-[var(--color-fg)] hover:bg-[var(--color-surface-warm)]"
+            >
+              Stand down
+            </button>
           )}
         </div>
       </aside>

--- a/components/EncounterToast.tsx
+++ b/components/EncounterToast.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { Check, X } from "@phosphor-icons/react/dist/ssr";
+import { Check, Sword, X } from "@phosphor-icons/react/dist/ssr";
 import { useGameStore } from "@/lib/state/game-store";
 import { FACTIONS } from "@/content/factions";
 import { RESOURCES } from "@/content/resources";
@@ -13,6 +13,8 @@ export default function EncounterToast() {
   const event = useGameStore((s) => s.lastEvent);
   const accept = useGameStore((s) => s.acceptEncounter);
   const dismiss = useGameStore((s) => s.dismissEncounter);
+  const view = useGameStore((s) => s.view);
+  const setView = useGameStore((s) => s.setView);
 
   const encounter = event?.encounter ?? null;
 
@@ -77,12 +79,26 @@ export default function EncounterToast() {
               </button>
             </>
           ) : (
-            <button
-              onClick={dismiss}
-              className="tactile inline-flex h-10 items-center gap-1.5 rounded-full border border-[var(--color-border)] px-3 text-sm text-[var(--color-fg)] hover:bg-[var(--color-surface-warm)]"
-            >
-              Stand down
-            </button>
+            <>
+              <button
+                onClick={dismiss}
+                className="tactile inline-flex h-10 items-center gap-1.5 rounded-full border border-[var(--color-border)] px-3 text-sm text-[var(--color-fg)] hover:bg-[var(--color-surface-warm)]"
+              >
+                Stand down
+              </button>
+              {view === "world" && (
+                <button
+                  onClick={() => {
+                    setView("biome");
+                    dismiss();
+                  }}
+                  className="tactile inline-flex h-10 items-center gap-1.5 rounded-full bg-[var(--color-accent)] px-3.5 text-sm font-medium text-[var(--color-bg)] shadow-[0_8px_24px_-12px_rgba(217,104,70,0.5)]"
+                >
+                  <Sword size={14} weight="fill" />
+                  Stand and fight
+                </button>
+              )}
+            </>
           )}
         </div>
       </aside>

--- a/lib/render/scenes/BiomeScene.ts
+++ b/lib/render/scenes/BiomeScene.ts
@@ -68,6 +68,7 @@ export class BiomeScene extends Phaser.Scene {
   private prevNpcHealth = new Map<string, number>();
   private prevPlayerHealth = -1;
   private seenPickupIds = new Set<string>();
+  private projectileLayer!: Phaser.GameObjects.Graphics;
 
   private playerGx = 0;
   private playerGy = 0;
@@ -107,6 +108,7 @@ export class BiomeScene extends Phaser.Scene {
     this.selectionRing.setVisible(false);
     this.playerShadow = this.add.graphics();
     this.playerLayer = this.add.graphics();
+    this.projectileLayer = this.add.graphics();
 
     // setZoom must precede centerOn -- centerOn uses the current zoom to
     // derive scrollX/Y, otherwise the camera lands somewhere far off.
@@ -208,7 +210,45 @@ export class BiomeScene extends Phaser.Scene {
     this.drawVisitors(world.npcs, world);
     this.detectHits(world.npcs, world.player.health);
     this.spawnPickupTexts(world.recentPickups);
+    this.drawProjectiles(world.recentProjectiles, world.ticks);
     this.drawSelection();
+  }
+
+  private drawProjectiles(
+    projectiles: { id: string; tick: number; fromGx: number; fromGy: number; toGx: number; toGy: number; color: number }[],
+    nowTick: number,
+  ) {
+    this.projectileLayer.clear();
+    for (const p of projectiles) {
+      const age = nowTick - p.tick;
+      if (age < 0 || age > 4) continue;
+      const alpha = Math.max(0.1, 1 - age / 4);
+      const fromCenter = tileCenter(p.fromGx, p.fromGy);
+      const toCenter = tileCenter(p.toGx, p.toGy);
+      const dx = toCenter.x - fromCenter.x;
+      const dy = toCenter.y - fromCenter.y;
+      const len = Math.hypot(dx, dy) || 1;
+      const ux = dx / len;
+      const uy = dy / len;
+      const margin = PLAYER_SIZE * 0.55;
+      const sx = fromCenter.x + ux * margin;
+      const sy = fromCenter.y + uy * margin;
+      const ex = toCenter.x - ux * margin;
+      const ey = toCenter.y - uy * margin;
+      const total = Math.hypot(ex - sx, ey - sy);
+      this.projectileLayer.lineStyle(2, p.color, alpha);
+      const segLen = 5;
+      const gapLen = 4;
+      let cur = 0;
+      while (cur < total) {
+        const a = Math.min(cur + segLen, total);
+        this.projectileLayer.beginPath();
+        this.projectileLayer.moveTo(sx + ux * cur, sy + uy * cur);
+        this.projectileLayer.lineTo(sx + ux * a, sy + uy * a);
+        this.projectileLayer.strokePath();
+        cur = a + gapLen;
+      }
+    }
   }
 
   private spawnPickupTexts(pickups: { id: string; kind: ResourceKind; amount: number }[]) {

--- a/lib/sim/combat.ts
+++ b/lib/sim/combat.ts
@@ -26,6 +26,7 @@ import {
   weaponReach,
   type WeaponInstance,
 } from "@/lib/sim/weapons";
+import { WEAPONS } from "@/content/weapons";
 import { bfs } from "@/lib/sim/path";
 import { goalTarget } from "@/lib/sim/goal";
 import type { ResourceKind } from "@/content/resources";
@@ -784,12 +785,7 @@ export function pruneDeadNpcs(npcs: Npc[]): Npc[] {
 }
 
 // Player-initiated attack: called from player-tick when pendingAction kicks in.
-export function resolvePlayerAttack(
-  player: Player,
-  npc: Npc,
-  rng: Rng,
-  ticks: number,
-): {
+export type PlayerAttackResult = {
   player: Player;
   npc: Npc;
   hits: CombatHit[];
@@ -798,7 +794,20 @@ export function resolvePlayerAttack(
   repPenaltyFactionId: string;
   repPenaltyAmount: number;
   attacked: boolean;
-} {
+  projectile: {
+    fromGx: number;
+    fromGy: number;
+    toGx: number;
+    toGy: number;
+  } | null;
+};
+
+export function resolvePlayerAttack(
+  player: Player,
+  npc: Npc,
+  rng: Rng,
+  ticks: number,
+): PlayerAttackResult {
   if (!npc.interior || player.combatCooldown > 0) {
     return {
       player,
@@ -809,6 +818,7 @@ export function resolvePlayerAttack(
       repPenaltyFactionId: npc.factionId,
       repPenaltyAmount: 0,
       attacked: false,
+      projectile: null,
     };
   }
   const here = globalToLocal(player.gx, player.gy);
@@ -825,6 +835,7 @@ export function resolvePlayerAttack(
       repPenaltyFactionId: npc.factionId,
       repPenaltyAmount: 0,
       attacked: false,
+      projectile: null,
     };
   }
   const damage = Math.max(
@@ -876,6 +887,15 @@ export function resolvePlayerAttack(
       items,
     };
   }
+  const ranged = weapon ? WEAPONS[weapon.kind].ranged : false;
+  const projectile = ranged
+    ? {
+        fromGx: player.gx,
+        fromGy: player.gy,
+        toGx: npc.rx * INTERIOR_W + npc.interior.lx,
+        toGy: npc.ry * INTERIOR_H + npc.interior.ly,
+      }
+    : null;
   return {
     player: nextPlayer,
     npc: updatedNpc,
@@ -885,6 +905,7 @@ export function resolvePlayerAttack(
     repPenaltyFactionId: npc.factionId,
     repPenaltyAmount,
     attacked: true,
+    projectile,
   };
 }
 

--- a/lib/sim/npc.ts
+++ b/lib/sim/npc.ts
@@ -11,6 +11,7 @@ import {
   type Goal,
 } from "@/lib/sim/goal";
 import type { WeaponInstance } from "@/lib/sim/weapons";
+import { ENGAGED_TTL_TICKS } from "@/lib/sim/combat";
 
 export type Intent = { rx: number; ry: number };
 
@@ -133,7 +134,13 @@ export type TickNpcCtx = {
   regionControl: Record<string, string>;
   npcs: Npc[];
   playerRegion: { rx: number; ry: number } | null;
+  playerReputation: Record<string, number>;
+  recentFactionAttacks: Record<string, number>;
+  ticks: number;
 };
+
+export const NPC_PERCEPTION_REGIONS = 3;
+export const FLEE_TTL_TICKS = 480;
 
 export function tickNpc(npc: Npc, ctx: TickNpcCtx): Npc {
   const { rng, mapW, mapH } = ctx;
@@ -189,7 +196,29 @@ export function tickNpc(npc: Npc, ctx: TickNpcCtx): Npc {
     return { ...moved, goal: advanceGoalState(moved, moved.goal) };
   }
 
-  const target = goalTarget(goal, npc, ctx.npcs);
+  // Region-level chase / flee override: when faction is hostile to the player
+  // and the player's region is within perception, head toward them. When
+  // friendly but the faction was attacked recently, drift away.
+  let target = goalTarget(goal, npc, ctx.npcs);
+  if (ctx.playerRegion) {
+    const dRegion = chebyshevR(npc.rx, npc.ry, ctx.playerRegion.rx, ctx.playerRegion.ry);
+    const repHostile = (ctx.playerReputation[npc.factionId] ?? 0) < 0;
+    const engaged =
+      npc.engagedTick !== null && ctx.ticks - npc.engagedTick < ENGAGED_TTL_TICKS;
+    if ((repHostile || engaged) && dRegion <= NPC_PERCEPTION_REGIONS) {
+      target = { rx: ctx.playerRegion.rx, ry: ctx.playerRegion.ry };
+    } else {
+      const lastAttacked = ctx.recentFactionAttacks[npc.factionId];
+      if (
+        !repHostile &&
+        lastAttacked !== undefined &&
+        ctx.ticks - lastAttacked < FLEE_TTL_TICKS &&
+        dRegion <= NPC_PERCEPTION_REGIONS
+      ) {
+        target = fleeTargetFromPlayer(npc, ctx.playerRegion, mapW, mapH);
+      }
+    }
+  }
   const candidates = passableNeighbors(npc.rx, npc.ry, mapW, mapH);
 
   if (candidates.length === 0) {
@@ -283,4 +312,24 @@ function passableNeighbors(
 
 function manhattan(ax: number, ay: number, bx: number, by: number): number {
   return Math.abs(ax - bx) + Math.abs(ay - by);
+}
+
+function chebyshevR(ax: number, ay: number, bx: number, by: number): number {
+  return Math.max(Math.abs(ax - bx), Math.abs(ay - by));
+}
+
+function fleeTargetFromPlayer(
+  npc: Npc,
+  playerRegion: { rx: number; ry: number },
+  mapW: number,
+  mapH: number,
+): { rx: number; ry: number } {
+  // Step away from the player on the dominant axis, clamped to map bounds.
+  const dx = npc.rx - playerRegion.rx;
+  const dy = npc.ry - playerRegion.ry;
+  const sx = dx === 0 ? 1 : Math.sign(dx);
+  const sy = dy === 0 ? 1 : Math.sign(dy);
+  const tx = Math.max(0, Math.min(mapW - 1, npc.rx + sx * 3));
+  const ty = Math.max(0, Math.min(mapH - 1, npc.ry + sy * 3));
+  return { rx: tx, ry: ty };
 }

--- a/lib/sim/player-tick.ts
+++ b/lib/sim/player-tick.ts
@@ -40,6 +40,13 @@ export type PlayerTickInput = {
   ticks: number;
 };
 
+export type ProjectileNotice = {
+  fromGx: number;
+  fromGy: number;
+  toGx: number;
+  toGy: number;
+};
+
 export type PlayerTickOutput = {
   player: Player;
   interiors: Record<string, BiomeInterior>;
@@ -47,6 +54,7 @@ export type PlayerTickOutput = {
   npcs: Npc[];
   playerReputation: Record<string, number>;
   pickups: PickupNotice[];
+  projectiles: ProjectileNotice[];
   death: boolean;
 };
 
@@ -55,6 +63,7 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
   const rng = input.rng;
   const ticks = input.ticks;
   const pickups: PickupNotice[] = [];
+  const projectiles: ProjectileNotice[] = [];
 
   if (player.combatCooldown > 0) {
     player = { ...player, combatCooldown: player.combatCooldown - 1 };
@@ -150,6 +159,7 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
         const out = resolvePlayerAttack(player, target, rng, ticks);
         if (out.attacked) {
           player = out.player;
+          if (out.projectile) projectiles.push(out.projectile);
           if (out.repPenaltyAmount > 0) {
             playerReputation = applyRepPenalty(
               playerReputation,
@@ -208,6 +218,7 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
     npcs,
     playerReputation,
     pickups,
+    projectiles,
     death: player.health <= 0,
   };
 }

--- a/lib/sim/world.ts
+++ b/lib/sim/world.ts
@@ -23,7 +23,7 @@ import { tickCombat } from "@/lib/sim/combat";
 
 export { biomeAt, isPassable, type Biome } from "@/lib/sim/biome";
 
-export const WORLD_VERSION = 7;
+export const WORLD_VERSION = 8;
 export const MAP_W = 32;
 export const MAP_H = 32;
 export const NPC_COUNT = 200;
@@ -45,6 +45,16 @@ export type PickupNotice = {
   tick: number;
   kind: import("@/content/resources").ResourceKind;
   amount: number;
+};
+
+export type ProjectileFx = {
+  id: string;
+  tick: number;
+  fromGx: number;
+  fromGy: number;
+  toGx: number;
+  toGy: number;
+  color: number;
 };
 
 export type World = {
@@ -74,6 +84,11 @@ export type World = {
   // BiomeScene drains them to spawn floating text and they fall off after
   // a short window.
   recentPickups: PickupNotice[];
+  // Same idea for ranged projectile fx — short-lived dotted-line shots.
+  recentProjectiles: ProjectileFx[];
+  // factionId -> last tick at which a member was attacked. Friendlies of
+  // an aggrieved faction flee from the player while this is fresh.
+  recentFactionAttacks: Record<string, number>;
   gameOver: boolean;
   gameOverReason: GameOverReason | null;
 };
@@ -100,6 +115,8 @@ export function createWorld(seed = Date.now() & 0xffffffff): World {
     playerReputation: {},
     factionRelations: {},
     recentPickups: [],
+    recentProjectiles: [],
+    recentFactionAttacks: {},
     gameOver: false,
     gameOverReason: null,
   };
@@ -153,6 +170,7 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
 
   const rng = createRng(world.rngState);
   const playerRegion = world.player ? globalToLocal(world.player.gx, world.player.gy) : null;
+  const ticks = world.ticks + 1;
   const tickCtx = {
     rng,
     mapW: MAP_W,
@@ -160,9 +178,11 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
     regionControl: world.regionControl,
     npcs: world.npcs,
     playerRegion: playerRegion ? { rx: playerRegion.rx, ry: playerRegion.ry } : null,
+    playerReputation: world.playerReputation,
+    recentFactionAttacks: world.recentFactionAttacks,
+    ticks,
   };
   let npcs = world.npcs.map((n) => tickNpc(n, tickCtx));
-  const ticks = world.ticks + 1;
 
   let player = world.player;
   let interiors = world.biomeInteriors;
@@ -171,6 +191,8 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
   let factionRelations = world.factionRelations;
   let playerReputation = world.playerReputation;
   let recentPickups = prunePickups(world.recentPickups, ticks);
+  let recentProjectiles = pruneProjectiles(world.recentProjectiles, ticks);
+  let recentFactionAttacks = world.recentFactionAttacks;
   const combatDeathEvents: WorldEvent[] = [];
   let gameOver: boolean = world.gameOver;
   let gameOverReason: GameOverReason | null = world.gameOverReason;
@@ -189,8 +211,42 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
     player = stepped.player;
     interiors = stepped.interiors;
     inventory = stepped.inventory;
+    const npcsBefore = npcs;
     npcs = stepped.npcs;
     playerReputation = stepped.playerReputation;
+    // Stamp the player's faction-attack ledger when an NPC took damage from
+    // the player this tick (detected by health drop on a still-living NPC).
+    for (const before of npcsBefore) {
+      const after = npcs.find((n) => n.id === before.id);
+      if (!after) {
+        // NPC removed from list — handled separately as a death.
+        continue;
+      }
+      if (after.combatHealth < before.combatHealth) {
+        recentFactionAttacks = {
+          ...recentFactionAttacks,
+          [after.factionId]: ticks,
+        };
+      }
+    }
+    if (stepped.projectiles.length > 0) {
+      let next = recentProjectiles;
+      for (const p of stepped.projectiles) {
+        next = [
+          ...next,
+          {
+            id: `proj-${ticks}-${next.length}`,
+            tick: ticks,
+            fromGx: p.fromGx,
+            fromGy: p.fromGy,
+            toGx: p.toGx,
+            toGy: p.toGy,
+            color: 0xd96846,
+          },
+        ];
+      }
+      recentProjectiles = next.slice(-12);
+    }
     if (stepped.pickups.length > 0) {
       let next = recentPickups;
       for (const p of stepped.pickups) {
@@ -313,6 +369,8 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
     factionRelations,
     playerReputation,
     recentPickups,
+    recentProjectiles,
+    recentFactionAttacks,
     recentEvents: startingEvents,
     gameOver,
     gameOverReason,
@@ -443,10 +501,18 @@ function dropDeathLoot(
 
 // Pickups are short-lived (UI hints). After ~10 ticks (~2.5s at 1x), drop.
 const PICKUP_TTL_TICKS = 10;
+const PROJECTILE_TTL_TICKS = 4;
 function prunePickups(prev: PickupNotice[], ticks: number): PickupNotice[] {
   const out: PickupNotice[] = [];
   for (const p of prev) {
     if (ticks - p.tick <= PICKUP_TTL_TICKS) out.push(p);
+  }
+  return out;
+}
+function pruneProjectiles(prev: ProjectileFx[], ticks: number): ProjectileFx[] {
+  const out: ProjectileFx[] = [];
+  for (const p of prev) {
+    if (ticks - p.tick <= PROJECTILE_TTL_TICKS) out.push(p);
   }
   return out;
 }


### PR DESCRIPTION
Builds on the Phase 3a sim foundations already merged via #16. This PR adds the AI behaviour and ranged-attack polish that was scoped out of 3a.

## Summary

- **Hostile chase across regions** — NPCs whose faction is hostile to the player (`playerReputation[factionId] < 0`) or that the player has personally attacked recently (`engagedTick` within 200 ticks) override their goal target to the player's region whenever the player is within 3 Chebyshev regions. Combined with the tile-level chase from 3a, an aggrieved faction's NPCs now converge on you across the world map.
- **Friendly flee** — `World.recentFactionAttacks` ledger tracks the last tick a member of each faction took a hit. Friendly NPCs (rep ≥ 0) of a recently-aggrieved faction within perception bias their target three regions away from the player on the dominant axis. Bias decays after ~480 ticks (~2 minutes at 1×).
- **Ranged sling end-to-end** — player ranged attacks now emit a `ProjectileFx` notice from `player-tick`. `tickWorld` writes it into a short-lived `recentProjectiles` ring buffer (4-tick TTL). `BiomeScene` draws a dotted line from the attacker tile to the target tile, fading as it ages.
- **Stand and fight CTA** — hostile encounters fired while the player is on the world map now show a "Stand and fight" button alongside "Stand down". Tapping it switches to biome view immediately.
- **Save migration** — bumps `WORLD_VERSION` 7 → 8 for the new World fields. Old saves regenerate via the existing version-mismatch path in `loadFromDisk`.

## Files changed

- `lib/sim/world.ts` — `recentProjectiles` + `recentFactionAttacks` on World, prune helpers, version bump, ledger update from `tickPlayer` projectile / damage output.
- `lib/sim/npc.ts` — `NPC_PERCEPTION_REGIONS = 3`, `FLEE_TTL_TICKS`, region-level chase + flee override in `tickNpc`, `chebyshevR` and `fleeTargetFromPlayer` helpers.
- `lib/sim/combat.ts` — `PlayerAttackResult.projectile`; emit projectile when the equipped weapon is ranged.
- `lib/sim/player-tick.ts` — collect `projectiles` from `resolvePlayerAttack` and surface them in `PlayerTickOutput`.
- `lib/render/scenes/BiomeScene.ts` — `projectileLayer` + `drawProjectiles` (dotted-line render with age-based alpha).
- `components/EncounterToast.tsx` — `Stand and fight` button when `view === "world"` on hostile encounters.

## Test plan

Open the Vercel preview on a phone.

### 1. Ranged sling
- [x] Gather reed + stone, craft a Sling from the inventory panel.
- [x] Walk to within 4 tiles of an NPC. Tap them → context menu → **Attack**.
- [x] A dotted line flashes from you to them; they take damage. You did not have to walk adjacent.
- [x] Continue until they die. No projectile fires when only a melee weapon is equipped.

### 2. Hostile chase across regions
- [x] Attack an NPC and walk one or two regions away. Within ~30s, NPCs of that faction within 3 regions converge on your region (visible if debug-mode NPC tokens are on; otherwise visible when one enters your interior).
- [x] Continue attacking that faction; rep tanks; their NPCs further away start chasing too.

### 3. Friendly flee
- [ ] After tanking rep with one faction, walk near a *different*, still-friendly faction's territory.
- [ ] When you attack any NPC of that friendly faction, members within 3 regions begin drifting away from your region (rather than continuing their original goal).

### 4. Stand and fight CTA
- [ ] Stay on the world map and wait for a hostile encounter toast. It now shows **Stand and fight** alongside **Stand down**.
- [ ] Tap it → view switches to biome immediately and the toast dismisses.

### 5. Save migration
- [ ] An existing save from the 3a build (version 7) loads as a fresh world (`createWorld`) without errors.

### 6. Build hygiene
- [ ] CI green: `npm run typecheck && npm run lint && npm run build` all pass (verified locally).

## Out of scope (Phase 4)

- NPCs equipping their own ranged weapons (currently NPC weapons are always melee).
- Line-of-sight check for ranged attacks (obstacles don't block shots yet).
- Workbench-gated crafting recipes.

https://claude.ai/code/session_01WaF1GjKeY3nv118Eh5FhrV