### PR TITLE
docs: refresh CLAUDE.md and README to reflect Phase 1-3 state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,19 @@ Design pillars (from `README.md`):
 
 Visual language is **Mini Motorways**: warm cream background, square region grid, soft pastels, a single muted-coral accent, geometric clarity over flourish.
 
+## What's playable today
+
+Phases 1–3 are merged. The current loop:
+
+- **Settle a home.** Tap a passable region on the world map to claim it; you respawn here on death.
+- **Forage.** Tap food and material dots in the biome to collect them. Walking drains energy (~33 steps per energy unit at full); zero energy starts starvation. Open the inventory pill and tap **Eat** on any food row to spend it for `+energy +health`.
+- **Craft.** Inventory panel has a Crafting section: stick (1 wood), club (2 wood + 1 stone), sling (2 reed + 1 stone). The highest-attack weapon whose reach covers the target equips implicitly. Durability ticks per landed hit.
+- **Combat.** Tap an NPC to open a small floating context menu; tap **Attack** and the player auto-chases until they're in reach, then trades blows. Damage numbers float; the defender flashes white. Sling fires a dotted projectile up to 4 tiles. Killing an NPC drops a faction-flavoured loot pile.
+- **NPC vs NPC.** NPCs of rival factions (or with the `violence` value) fight when they share a region. Visible at tile level inside the player's interior; resolved abstractly off-screen, swinging faction `power` and `factionRelations` over time.
+- **Hostile chase / friendly flee.** Once you've crossed a faction (rep < 0, or you've personally hit a member), members within 3 regions converge on the player's region. Friendlies of an aggrieved faction drift away.
+- **Death persistence.** Inventory + carried weapons drop as a `fromDeath` loot pile at the death tile. Respawn at home with no gear; walk back to recover it. World keeps running.
+- **Debug mode.** Bug toggle in the top pill exposes a stats overlay (npcs.length, ticks, player coords, per-faction power and player rep), shows region-level NPC tokens + move telegraphs on the world map, surfaces Teleport / Inspect biome on RegionPanel, and shows the EncounterFeed. Off by default for normal play.
+
 ## Tech stack
 
 | Concern | Choice | Notes |
@@ -56,30 +69,73 @@ npm run start          # serve the production build locally
 app/                  Next.js App Router
   layout.tsx          Outfit font, viewport, PWA meta
   page.tsx            Landing — New Game / Continue
-  play/page.tsx       Game shell — mounts Phaser + HUD + panels
+  play/page.tsx       Game shell — mounts Phaser + HUD + panels + tutorial
 components/
   PhaserGame.tsx      Client-only wrapper that creates Phaser.Game
-  hud/HUD.tsx         Floating top pill (home, ticks, pause, speed)
-  panels/NpcPanel.tsx Slide-up details for the selected NPC
-  panels/RegionPanel.tsx Slide-up details for the selected region
+  TutorialModal.tsx   7-page tutorial fired on startNew (Skip/Begin)
+  EncounterToast.tsx  Toast for friendly/hostile encounters (Stand down / Accept)
+  EncounterFeed.tsx   Bottom-right combat/event log (debug-mode only)
+  FactionLegend.tsx   Faction colour swatch list
+  NpcContextMenu.tsx  Floating tap menu (Examine / Attack), draggable
+  RecenterButton.tsx  Snap camera back to player after panning
+  hud/HUD.tsx         Top pill (home, ticks, pause, speed, biome/world toggle,
+                      faction-zone eye toggle, debug bug), health/energy/inventory
+                      strips, in-combat dot, branched game-over modal,
+                      collapsible debug stats overlay
+  panels/NpcPanel.tsx     Stance + combat stats + matchup + Attack
+  panels/RegionPanel.tsx  Held-by, food list, Travel/Claim, debug Teleport/Inspect
+  panels/InventoryPanel.tsx  Materials with Eat, Weapons, Crafting, Gear placeholder
+  panels/ShapeBadge.tsx   Tiny faction-shape icon used by panels
 content/              Data-driven content
-  factions.ts         Three factions: id, name, color, values
+  factions.ts         Factions: id, name, color, shape, values
   traits.ts           Trait + name pools
   biomes.ts           Biome metadata: title, blurb, swatch, passable
+  resources.ts        9 resources (5 food + wood/reed/stone/ore), biome density
+  weapons.ts          Stick/club/sling: attack, reach, durability, ranged, recipe
 lib/
   sim/                Pure-TS deterministic simulation (no Phaser, no React)
-    world.ts          World shape, createWorld, tickWorld, WORLD_VERSION
-    npc.ts            NPC type, spawnNpc, tickNpc (telegraph + move logic)
-    faction.ts        FactionState (reputation, power)
-    events.ts         WorldEvent type, maybeEmitEvent
-    biome.ts          biomeAt, isPassable
+    world.ts          World shape, createWorld, tickWorld, WORLD_VERSION,
+                      claimHome, ensureInteriorsForRegion, dropDeathLoot
+    npc.ts            Npc type, spawnNpc, tickNpc (region-level), region-
+                      level chase / flee override using playerReputation +
+                      recentFactionAttacks
+    goal.ts           Goal kinds (wander/gather/patrol/raid/trade), pickGoal,
+                      goalTarget, isGoalDone, advanceGoalState
+    combat.ts         tickCombat (interior + region), resolvePlayerAttack,
+                      tile-level pathing, materializeInteriorSlot, projectile
+                      emission, NPC-vs-NPC at both scales, ENGAGED_TTL_TICKS
+    weapons.ts        WeaponInstance, affordable/spendRecipe/makeWeapon,
+                      pickWeaponForRange, consumeUse
+    player.ts         Player type, PlayerStats (speed/perception/atk/def/reach),
+                      PendingAction (collect | attack), createPlayer
+    player-tick.ts    tickPlayer: walk, chase NPCs while pendingAction.attack,
+                      pickup loot, manual eat hooked through store, projectile
+                      emission, starvation
+    faction.ts        FactionState (reputation, power), per-player rep helpers
+                      (gain/lose/playerRepOf), pairKey/getRelation/nudgeRelation,
+                      isFactionHostile predicate
+    events.ts         WorldEvent type, EncounterPayload, buildEncounterEvent
+    biome.ts          biomeAt, isPassable, blendNoise
+    biome-interior.ts INTERIOR_W=20, generateInterior, BiomeInterior with
+                      obstacles + resources + loot, addLoot/removeLoot,
+                      findPassableTile
+    path.ts           bfs (small grid), bfsPredicate (lazy global tile)
     rng.ts            Seeded mulberry32 — every random in the sim goes through this
   render/             Phaser-side code only (no React imports here)
     scenes/BootScene.ts
-    scenes/WorldScene.ts  Tilemap, grid, NPC sprites, telegraph visuals, input
+    scenes/WorldScene.ts   World map: biome tiles, faction-zone cross-hatch,
+                            home marker, player marker, debug-only NPC tokens
+                            and move telegraphs
+    scenes/BiomeScene.ts   Tile-level: tile fills + obstacles, resources, loot,
+                            visitor sprites that read npc.interior, damage-number
+                            text pool, hit flash, projectile dotted lines,
+                            pickup toasts
     bus.ts            mitt-based pub/sub — currently just for legacy events
   state/
-    game-store.ts     Zustand store: world, paused, speed, selections
+    game-store.ts     Zustand store: world, paused, speed, view, selections,
+                      inventory/tutorial/debug toggles, mapShowFactions,
+                      npcContextMenu, all game actions (craft, attackNpc, eatFood,
+                      teleportToRegion, inspectBiome, openInventory…)
   save/
     db.ts             Dexie schema + saveWorld / loadWorld / hasSave
 public/
@@ -114,7 +170,7 @@ If you add stochastic behaviour, take the rng as a parameter (see `tickNpc`) —
 
 ### 4. Save migrations via `WORLD_VERSION`
 
-`lib/sim/world.ts` exports `WORLD_VERSION` (currently `3`). The store's `loadFromDisk` discards saves whose version doesn't match and starts a fresh world. **Bump this whenever you change the `World`, `Npc`, `FactionState`, or related shapes.** This keeps users from booting into corrupt half-migrated state on the dev branch.
+`lib/sim/world.ts` exports `WORLD_VERSION` (currently `8`). The store's `loadFromDisk` discards saves whose version doesn't match and starts a fresh world. **Bump this whenever you change the `World`, `Npc`, `FactionState`, `Player`, `BiomeInterior`, or related shapes.** This keeps users from booting into corrupt half-migrated state on the dev branch.
 
 ### 5. Phaser is mounted client-only
 
@@ -122,7 +178,13 @@ If you add stochastic behaviour, take the rng as a parameter (see `tickNpc`) —
 
 ### 6. Game loop drives ticks via Phaser
 
-The Phaser `WorldScene.update(_, delta)` accumulates real time, scales by `store.speed`, and calls `store.tick()` every `tickStepMs = 250ms`. So 1× = 4 ticks/sec, 4× = 16 ticks/sec. Sim cooldowns are expressed in ticks; convert mentally with `ticks * 250ms`.
+Both Phaser scenes (`WorldScene` and `BiomeScene`) accumulate real time in `update(_, delta)`, scale by `store.speed`, and call `store.tick()` every `tickStepMs = 250ms`. So 1× = 4 ticks/sec, 4× = 16 ticks/sec. Sim cooldowns are expressed in ticks; convert mentally with `ticks * 250ms`. The active scene is chosen by `store.view` (`world` ↔ `biome`) — switching views starts/stops the corresponding scene, and only one runs at a time.
+
+### 8. Two-scale NPC movement
+
+NPCs canonically live at the **region level** (`rx`, `ry`). When their region matches the player's region, `lib/sim/combat.ts:tickInteriorCombat` materialises an `interior: { lx, ly, … }` slot and steps them tile-by-tile through the biome interior with one-step BFS over obstacles. The region-level `tickNpc` early-returns for these NPCs so they don't double-tick. When they leave (transit through an edge tile), `interior` clears and they go back to region-level movement.
+
+Off-screen NPCs of rival factions sharing a region resolve fights abstractly via `tickRegionCombat`. Inside the player's interior, the same NPCs fight at tile level. The single canonical NPC list is `world.npcs` — there is no parallel `combatants[]`.
 
 ### 7. Mobile-first defaults
 
@@ -171,27 +233,50 @@ Design dials (from the taste skill, tuned for this project): **DESIGN_VARIANCE 4
 
 ## Sim model and tunable constants
 
-The world is a `MAP_W × MAP_H` square grid (currently 12 × 12) of *regions*. Each region has a biome derived deterministically from `(x, y)` via `biomeAt`. Water is impassable.
+The world is a `MAP_W × MAP_H` square grid (currently **32 × 32**) of *regions*. `NPC_COUNT = 200`. Each region has a biome derived deterministically from `(x, y)` via `biomeAt`. Water is impassable. Each region also has a lazily-generated **biome interior** (an `INTERIOR_W × INTERIOR_H = 20 × 20` tile grid in `lib/sim/biome-interior.ts`) used when the player's view is `biome` and for tile-level NPC fights.
 
-NPCs occupy one region at a time (`rx`, `ry`). Movement is a four-state cycle:
+### Region-level NPC movement
 
-1. **Idle** — `moveCooldown` counts down from a value in `[IDLE_MIN, IDLE_MAX]` ticks (3–7.5s).
-2. **Decide** — when cooldown hits 0, roll `MOVE_CHANCE` (0.5) against picking an adjacent passable region as `intent`.
-3. **Telegraph** — if `intent` is set, cooldown becomes `TELEGRAPH_TICKS` (~2s). The render layer paints a faded faction-coloured ghost square at the target plus a dotted pulsing connector.
-4. **Execute** — on the next 0-tick, snap `rx/ry` to `intent`, clear `intent`, return to idle. The render layer detects the rx/ry change and tweens the sprite ~750ms with a trail line.
+NPCs canonically occupy one region at a time (`rx`, `ry`). When their region differs from the player's, `tickNpc` runs the four-state cycle:
 
-All five constants live at the top of `lib/sim/npc.ts`:
+1. **Idle** — `moveCooldown` counts down from a value in `[IDLE_MIN, IDLE_MAX]` ticks.
+2. **Decide** — when cooldown hits 0, the NPC consults its `goal` (wander/gather/patrol/raid/trade) for a target region, biased by region control. With probability `MOVE_CHANCE`, picks the best adjacent passable region toward target as `intent`.
+3. **Telegraph** — if `intent` is set, cooldown becomes `TELEGRAPH_TICKS`. The render layer paints a faded faction-coloured ghost square at the target plus a dotted pulsing connector. **Debug-mode-only** — the world map is otherwise clean.
+4. **Execute** — on the next 0-tick, snap `rx/ry` to `intent`, clear `intent`, advance goal state.
+
+Constants at the top of `lib/sim/npc.ts`:
 
 ```ts
 const IDLE_MIN = 12;        // ticks
 const IDLE_MAX = 30;
 const TELEGRAPH_TICKS = 8;
 const MOVE_CHANCE = 0.5;
+export const NPC_PERCEPTION_REGIONS = 3;  // chase / flee perception
+export const FLEE_TTL_TICKS = 480;        // friendly-flee bias decay (~2 min @ 1×)
 ```
 
-If you change pacing, **bump `WORLD_VERSION`** so existing saves don't get out-of-date cooldown distributions. (Adding new optional fields is also a `WORLD_VERSION` bump.)
+A region-level **chase / flee override** sits at the top of `tickNpc`: if the NPC's faction is hostile to the player (rep < 0 or `engagedTick` recent) and the player's region is within `NPC_PERCEPTION_REGIONS`, override `goalTarget` to the player's region. If a friendly faction was attacked recently (`world.recentFactionAttacks[factionId]` within `FLEE_TTL_TICKS`), bias the target three regions away from the player.
 
-`AUTOSAVE_EVERY_TICKS = 60` in `lib/state/game-store.ts` — the world snapshots to IndexedDB every 60 ticks (~15s at 1×).
+### Tile-level NPC movement (player's region)
+
+When `npc.rx,ry === player region`, `lib/sim/combat.ts:tickInteriorCombat` takes over. NPCs get a nullable `interior: { lx, ly, tileIntent, stepCooldown, lastHitTick, wanderUntil }` slot, materialised on entry, cleared when they leave. Each tick they pick a tile target via `pickDynamicTileTarget` (player tile if hostile, hostile-faction NPC tile, trade peer's tile, region-edge if goal points elsewhere, random edge if `wanderUntil` lapsed) then BFS one step toward it. Reaching an edge tile transits the NPC to the neighbour region.
+
+### Combat resolution
+
+- `Player.stats`: `{ speed, perception, attack, defense, reach }` (defaults 2/6/1/0/1 in `lib/sim/player.ts`).
+- `Npc` combat fields: `combatHealth/Max`, `combatAttack`, `combatDefense`, `combatReach=1`, `combatCooldown`, `combatIntent`, `weapon`, `engagedTick`. Stat values seeded from faction values + traits at spawn.
+- Damage: `max(1, attacker.attack + weaponBonus - defender.defense)`. `COMBAT_COOLDOWN_TICKS = 4` between attacks.
+- Player attack flow: tap NPC → context menu → **Attack** sets `pendingAction.attack`. Each tick `tickPlayer` re-plots a chase route to within reach of the NPC's current tile until they're adjacent or in ranged reach. On contact `resolvePlayerAttack` lands the hit; `pendingAction` persists until the NPC dies, leaves the region, or the player walks elsewhere.
+- Off-screen NPC fights: `tickRegionCombat` samples up to `REGION_PAIRS_PER_TICK = 4` hostile pairs per region, exchanges symmetric attacks (capped at `MAX_REGION_HITS_PER_TICK = 6`), and on death shifts faction `power` and `factionRelations`.
+
+### Other tunables
+
+- `AUTOSAVE_EVERY_TICKS = 60` in `lib/state/game-store.ts` — the world snapshots to IndexedDB every 60 ticks (~15s at 1×).
+- `WALK_ENERGY_PER_STEP = 0.3`, `STARVE_TICKS_PER_DAMAGE = 80`, `EAT_ENERGY_PER_FOOD = 3`, `EAT_HEALTH_PER_FOOD = 1`.
+- `PICKUP_TTL_TICKS = 10`, `PROJECTILE_TTL_TICKS = 4` — UI ring buffers in `world.ts`.
+- `ENGAGED_TTL_TICKS = 200` in `combat.ts` — pursuit memory for NPCs the player has hit.
+
+If you change pacing or shape, **bump `WORLD_VERSION`** so existing saves don't desync.
 
 ## Common tasks
 
@@ -225,7 +310,32 @@ Edit constants at the top of `lib/sim/npc.ts`. Bump `WORLD_VERSION` so old saves
 
 ### Change the visual telegraph
 
-Search `WorldScene.ts` for `npc.intent` and `view.intent`. The ghost square + dotted connector + alpha pulse all live in one block.
+Search `WorldScene.ts` for `npc.intent` and `renderTelegraphs`. The ghost square + dotted connector + alpha pulse all live in one block. Note this layer only renders when `useGameStore.getState().debugMode` is true.
+
+### Add a weapon
+
+1. Append a `WeaponKind` entry to `content/weapons.ts` with `attack`, `reach`, `durability`, `ranged`, `recipe`, `swatch`.
+2. The InventoryPanel iterates `WEAPON_KINDS` so the new recipe shows up automatically.
+3. `pickWeaponForRange` will pick it when its reach covers the target.
+4. No `WORLD_VERSION` bump needed unless you also change the `WeaponInstance` shape.
+
+### Add a resource
+
+1. Append to the `ResourceKind` union and `RESOURCES` map in `content/resources.ts`. Set `food: true` if it should be eatable.
+2. Add it to the relevant biome's `BIOME_RESOURCES` list.
+3. Render its icon in `BiomeScene.drawResourceIcon` (mirror an existing case).
+4. Bump `WORLD_VERSION` if any code reads/writes the new key from saved interiors.
+
+### Tune combat or AI
+
+- Per-attack damage / cooldown / weapons: `lib/sim/combat.ts` (`COMBAT_COOLDOWN_TICKS`, `ENGAGED_TTL_TICKS`, `REGION_PAIRS_PER_TICK`).
+- Region chase / friendly flee perception: `NPC_PERCEPTION_REGIONS`, `FLEE_TTL_TICKS` in `lib/sim/npc.ts`.
+- Player rep penalties: `resolvePlayerAttack` in `lib/sim/combat.ts` (5 per hit, +10 on kill by default).
+- Faction-vs-faction relation drift: `nudgeRelation` calls in `tickRegionCombat` / `attackNpcByNpc`.
+
+### Add a HUD / panel surface
+
+Mount in `app/play/page.tsx`. Read selection / state from the Zustand store. Reuse the slide-up panel chrome — `rounded-3xl border bg-[var(--color-surface)] shadow-[…]`. If the surface owns its own selection key (like `inventoryOpen` or `npcContextMenu`), wire mutually-exclusive logic in the store action that opens it. Hit targets ≥ 44px on mobile.
 
 ## Coding conventions
 
@@ -277,7 +387,12 @@ Don't add these without an explicit user ask. They've been considered and deferr
 - **Multiplayer / netcode.**
 - **Cloud save sync** (Vercel KV / Postgres). IndexedDB only for now.
 - **Service worker / offline mode.** PWA manifest only.
-- **Combat, inventory, dialogue trees.** Stub data structures only.
+- **Workbench / tool-gated crafting.** Phase 4. The InventoryPanel has a "Gear (coming soon)" placeholder.
+- **Sword / bow / armour / status effects.** Phase 4+.
+- **Group combat / formations.** Future.
+- **Dialogue trees.** Stub only — encounters are friendly-gift / hostile-fight today.
+- **Line-of-sight for ranged attacks.** Sling shots ignore obstacles; LoS lands later.
+- **NPCs equipping their own weapons.** NPC `weapon` field exists but spawn always sets it to null.
 - **Real art assets.** Placeholder solid-disc PNGs and procedural tile colours are deliberate.
 - **Reintroducing Unity, native, 3D.**
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ Inspired by Spore and D&D:
 - The world remembers your actions
 - Factions, cities, and conflicts persist beyond a single character
 
+## What's playable today
+
+The game is in early but functional shape. The current loop on the `main` branch:
+
+- **A 32 × 32 region world** of biomes (grass / forest / sand / stone / water), held by three competing factions whose territory accretes over time as their NPCs occupy it. 200 autonomous NPCs roam the map with faction-flavoured goals (wander / gather / patrol / raid / trade).
+- **Settle, forage, survive.** Tap a passable region to claim home. Tap food and material dots in the biome to gather them; walking drains energy, and zero energy starts starvation. Open the inventory pill to **Eat** food on demand for `+energy +health`.
+- **Craft and fight.** Stick / club / sling craft from foraged materials. Tap an NPC to open a small floating context menu (Examine / Attack); the player auto-chases until they're in reach, then trades blows. Sling fires at up to 4 tiles with a dotted projectile.
+- **Faction relations matter.** Per-player reputation drives encounter sentiment. Attacking an NPC tanks rep with their faction; once you're hostile, members within ~3 regions converge on you. Friendlies of an aggrieved faction drift away. Off-screen, rival-faction NPCs fight each other — kills shift faction power and inter-faction relations over time.
+- **Death is a setback, not a reset.** Inventory + carried weapons drop as a `fromDeath` loot pile at the death tile; you respawn at home with no gear, and the rest of the world (NPCs, factions, biomes, relations) keeps running. Walk back to recover what you lost.
+- **Mini Motorways aesthetic.** Warm cream background, square region grid, soft pastels, single muted-coral accent. Faction territory renders as a semi-transparent diagonal cross-hatch that visually merges across adjacent same-faction regions.
+- **Debug mode.** A bug toggle in the top pill exposes a stats overlay (NPC count, ticks, per-faction power and player rep), shows region-level NPC tokens + telegraphs on the world map, surfaces Teleport / Inspect biome on RegionPanel, and shows an EncounterFeed of recent combat deaths. Off by default.
+
+Bigger features intentionally not built yet: a workbench / tool-gated crafting graph, sword / bow / armour, status effects, group combat, dialogue trees, multiplayer, cloud sync. See [`CLAUDE.md`](./CLAUDE.md) for the contributor-facing scope list.
+
 ## Inspirations
 
 - **Skyrim** – Open world, factions, reputation, story depth
@@ -86,18 +100,24 @@ EmergentRPG is built as a mobile-first web app, designed to be developed from a 
 ├── app/                    # Next.js App Router
 │   ├── layout.tsx          # Root layout, viewport + PWA meta
 │   ├── page.tsx            # Landing (New Game / Continue)
-│   └── play/page.tsx       # Game shell (Phaser + HUD + panels)
-├── components/             # React UI (HUD, panels, Phaser wrapper)
+│   └── play/page.tsx       # Game shell (Phaser + HUD + panels + tutorial)
+├── components/             # React UI: HUD, slide-up panels, NPC context
+│                           # menu, encounter toast/feed, tutorial modal
 ├── lib/
 │   ├── sim/                # Deterministic world simulation
-│   ├── render/             # Phaser scenes + React↔Phaser event bus
+│   │                       # world / npc / goal / combat / weapons / player /
+│   │                       # player-tick / faction / events / biome /
+│   │                       # biome-interior / path / rng
+│   ├── render/             # Phaser scenes (WorldScene + BiomeScene) + bus
 │   ├── state/              # Zustand store
 │   └── save/               # Dexie schema (IndexedDB)
-├── content/                # Data-driven content (factions, traits)
+├── content/                # Data-driven content
+│                           # factions / traits / biomes / resources / weapons
 ├── public/
 │   ├── manifest.webmanifest
 │   └── icons/              # Placeholder PWA icons
 ├── .claude/                # SessionStart hook + permissions
+├── CLAUDE.md               # Contributor / agent orientation
 ├── CONTRIBUTING.md
 └── README.md
 ```


### PR DESCRIPTION
Phase 1–3 are all merged into `main`. The docs were still describing the pre-Phase-3 state ("Combat, inventory, dialogue trees. Stub data structures only.", 12×12 grid, NPCs with no goals, etc.). This PR refreshes them to describe what's actually live.

## CLAUDE.md

- New **"What's playable today"** section summarising the live loop in one paragraph each:
  - Settle a home base and respawn there on death
  - Forage with manual **Eat** in the inventory
  - Craft stick / club / sling
  - Tap-to-attack via floating context menu, auto-chase, melee + ranged
  - NPC ↔ NPC fights at tile level (visible) and region level (abstract)
  - Hostile chase / friendly flee across regions
  - Death persistence (loot pile at death tile, world keeps running)
  - Debug mode toggle
- **Repository tour** rewritten to list the actual current files: `combat.ts`, `weapons.ts`, `player.ts`, `player-tick.ts`, `goal.ts`, `biome-interior.ts`, `path.ts` on the sim side; `BiomeScene` + `WorldScene`; the new panel / modal / toast / feed components; the new content data files.
- **Sim model** rewritten:
  - 32 × 32 region grid, 200 NPCs
  - Two-scale NPC movement (region-level `tickNpc` + tile-level `tickInteriorCombat`)
  - Combat resolution constants (`COMBAT_COOLDOWN_TICKS`, `ENGAGED_TTL_TICKS`)
  - Region chase / friendly flee (`NPC_PERCEPTION_REGIONS`, `FLEE_TTL_TICKS`)
  - Pickup / projectile TTLs, autosave cadence
  - Walk / starvation / eat tunables
- New architecture invariant for the **two-scale NPC system** (canonical region position; tile slot lit up only when in player's region).
- `WORLD_VERSION` bumped to **8** in the save-migration invariant.
- Common-tasks gained recipes for **Add a weapon**, **Add a resource**, **Tune combat or AI**, **Add a HUD / panel surface**.
- **Out-of-scope** list updated:
  - Combat / inventory are no longer stubs.
  - Workbench, sword / bow / armour, dialogue trees, ranged line-of-sight, NPCs equipping weapons explicitly deferred.

## README.md

- New **"What's playable today"** section before Inspirations describing the same live loop for non-contributor readers.
- Repository structure rewritten to match the actual sim / content / components layout.

## Test plan

- [ ] Render `CLAUDE.md` and `README.md` on GitHub and confirm headings, code fences, and tables look right.
- [ ] Spot-check that file paths referenced in the Repository tour exist on `main`.

https://claude.ai/code/session_01WaF1GjKeY3nv118Eh5FhrV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaF1GjKeY3nv118Eh5FhrV)_