### PR TITLE
Phase 4: workbench, recipes, obstacle context menu, tool-gated harvesting

### DIFF
--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -6,8 +6,10 @@ import { Suspense, useEffect } from "react";
 import HUD from "@/components/hud/HUD";
 import NpcPanel from "@/components/panels/NpcPanel";
 import NpcContextMenu from "@/components/NpcContextMenu";
+import ObstacleContextMenu from "@/components/ObstacleContextMenu";
 import RegionPanel from "@/components/panels/RegionPanel";
 import InventoryPanel from "@/components/panels/InventoryPanel";
+import WorkbenchPanel from "@/components/panels/WorkbenchPanel";
 import TutorialModal from "@/components/TutorialModal";
 import RecenterButton from "@/components/RecenterButton";
 import EncounterToast from "@/components/EncounterToast";
@@ -51,8 +53,10 @@ function PlayInner() {
       <FactionLegend />
       <NpcPanel />
       <NpcContextMenu />
+      <ObstacleContextMenu />
       <RegionPanel />
       <InventoryPanel />
+      <WorkbenchPanel />
       <EncounterToast />
       <EncounterFeed />
       <TutorialModal />

--- a/components/ObstacleContextMenu.tsx
+++ b/components/ObstacleContextMenu.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { Eye, Hammer } from "@phosphor-icons/react/dist/ssr";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useGameStore } from "@/lib/state/game-store";
+import type { ObstacleKind } from "@/lib/sim/biome-interior";
+import { hasTool } from "@/lib/sim/tools";
+
+const MENU_WIDTH = 220;
+const MENU_HEIGHT_EST = 200;
+const MENU_OFFSET = 16;
+const MENU_PADDING = 12;
+
+const OBSTACLE_LABEL: Record<ObstacleKind, string> = {
+  tree: "Tree",
+  rock: "Rock",
+  cactus: "Cactus",
+  bush: "Bush",
+  workbench: "Workbench",
+};
+
+const OBSTACLE_BLURB: Record<ObstacleKind, string> = {
+  tree: "Sturdy wood. Needs an axe to chop.",
+  rock: "Stone, maybe ore. Needs a pickaxe.",
+  cactus: "Spiny. Best to walk around.",
+  bush: "Low growth. Nothing to harvest.",
+  workbench: "A bench for tools and advanced weapons.",
+};
+
+type ActionDef = {
+  id: string;
+  label: string;
+  description?: string;
+  primary?: boolean;
+  disabled?: boolean;
+  icon: "eye" | "hammer";
+  onClick: () => void;
+};
+
+export default function ObstacleContextMenu() {
+  const ctx = useGameStore((s) => s.obstacleContextMenu);
+  const close = useGameStore((s) => s.closeObstacleContextMenu);
+  const interact = useGameStore((s) => s.interactWithObstacle);
+  const player = useGameStore((s) => s.world?.player ?? null);
+
+  const ref = useRef<HTMLDivElement | null>(null);
+  const dragOffset = useRef<{ dx: number; dy: number } | null>(null);
+  const [drag, setDrag] = useState<{ left: number; top: number } | null>(null);
+
+  const lastKeyRef = useRef<string | null>(null);
+  const ctxKey = ctx ? `${ctx.rx}-${ctx.ry}-${ctx.lx}-${ctx.ly}` : null;
+  if (ctxKey !== lastKeyRef.current) {
+    lastKeyRef.current = ctxKey;
+    if (drag !== null) {
+      Promise.resolve().then(() => setDrag(null));
+    }
+  }
+
+  useEffect(() => {
+    if (!ctx) return;
+    const handler = (e: MouseEvent | TouchEvent) => {
+      if (!ref.current) return;
+      if (ref.current.contains(e.target as Node)) return;
+      close();
+    };
+    const t = window.setTimeout(() => {
+      window.addEventListener("mousedown", handler);
+      window.addEventListener("touchstart", handler);
+    }, 0);
+    return () => {
+      window.clearTimeout(t);
+      window.removeEventListener("mousedown", handler);
+      window.removeEventListener("touchstart", handler);
+    };
+  }, [ctx, close]);
+
+  const pos = useMemo(() => {
+    if (!ctx) return null;
+    if (drag) return drag;
+    const vw = typeof window === "undefined" ? 1024 : window.innerWidth;
+    const vh = typeof window === "undefined" ? 768 : window.innerHeight;
+    const placeBelow = ctx.y < vh / 2;
+    let left = ctx.x + MENU_OFFSET;
+    let top = placeBelow ? ctx.y + MENU_OFFSET : ctx.y - MENU_HEIGHT_EST - MENU_OFFSET;
+    left = clamp(left, MENU_PADDING, vw - MENU_WIDTH - MENU_PADDING);
+    top = clamp(top, MENU_PADDING, vh - MENU_HEIGHT_EST - MENU_PADDING);
+    return { left, top };
+  }, [ctx, drag]);
+
+  if (!ctx || !player || !pos) return null;
+  const { rx, ry, lx, ly, kind } = ctx;
+  const label = OBSTACLE_LABEL[kind];
+  const blurb = OBSTACLE_BLURB[kind];
+
+  const actions: ActionDef[] = [
+    {
+      id: "examine",
+      label: "Examine",
+      icon: "eye",
+      onClick: () => close(),
+    },
+  ];
+  if (kind === "tree") {
+    const have = hasTool(player.tools, "axe");
+    actions.push({
+      id: "chop",
+      label: "Chop",
+      description: have ? "drops wood · uses axe" : "needs axe",
+      primary: true,
+      disabled: !have,
+      icon: "hammer",
+      onClick: () => {
+        if (!have) return;
+        interact(rx, ry, lx, ly, "harvest");
+      },
+    });
+  } else if (kind === "rock") {
+    const have = hasTool(player.tools, "pickaxe");
+    actions.push({
+      id: "mine",
+      label: "Mine",
+      description: have ? "drops stone · rare ore" : "needs pickaxe",
+      primary: true,
+      disabled: !have,
+      icon: "hammer",
+      onClick: () => {
+        if (!have) return;
+        interact(rx, ry, lx, ly, "harvest");
+      },
+    });
+  } else if (kind === "workbench") {
+    actions.push({
+      id: "craft",
+      label: "Craft",
+      description: "open workbench",
+      primary: true,
+      icon: "hammer",
+      onClick: () => interact(rx, ry, lx, ly, "workbench"),
+    });
+  }
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    if (!ref.current) return;
+    const rect = ref.current.getBoundingClientRect();
+    dragOffset.current = { dx: e.clientX - rect.left, dy: e.clientY - rect.top };
+    (e.target as Element).setPointerCapture?.(e.pointerId);
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!dragOffset.current) return;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const left = clamp(
+      e.clientX - dragOffset.current.dx,
+      MENU_PADDING,
+      vw - MENU_WIDTH - MENU_PADDING,
+    );
+    const top = clamp(
+      e.clientY - dragOffset.current.dy,
+      MENU_PADDING,
+      vh - MENU_HEIGHT_EST - MENU_PADDING,
+    );
+    setDrag({ left, top });
+  };
+  const onPointerUp = (e: React.PointerEvent) => {
+    dragOffset.current = null;
+    (e.target as Element).releasePointerCapture?.(e.pointerId);
+  };
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      aria-label={`${label} actions`}
+      className="pointer-events-auto absolute z-30 flex flex-col rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-1.5 shadow-[0_16px_40px_-16px_rgba(44,40,32,0.45)]"
+      style={{ left: pos.left, top: pos.top, width: MENU_WIDTH }}
+    >
+      <div
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        className="flex cursor-grab items-center gap-2 px-2 py-1.5 active:cursor-grabbing touch-none select-none"
+      >
+        <ObstacleSwatch kind={kind} />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-[var(--color-fg)]">
+            {label}
+          </div>
+          <div className="font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+            r({rx},{ry}) · drag to move
+          </div>
+        </div>
+      </div>
+      <div className="my-0.5 h-px bg-[var(--color-border)]" aria-hidden />
+      <p className="px-2.5 pb-1 pt-0.5 text-xs leading-snug text-[var(--color-fg-muted)]">
+        {blurb}
+      </p>
+      <div className="my-0.5 h-px bg-[var(--color-border)]" aria-hidden />
+      {actions.map((a) => (
+        <button
+          key={a.id}
+          onClick={a.onClick}
+          disabled={a.disabled}
+          className={`tactile inline-flex items-center gap-2 rounded-xl px-2 py-2 text-left text-sm hover:bg-[var(--color-surface-warm)] disabled:cursor-not-allowed disabled:opacity-50 ${
+            a.primary
+              ? "text-[var(--color-accent)]"
+              : "text-[var(--color-fg)]"
+          }`}
+        >
+          {a.icon === "eye" ? (
+            <Eye size={14} weight="duotone" className="text-[var(--color-fg-muted)]" />
+          ) : (
+            <Hammer size={14} weight="fill" />
+          )}
+          <span className="min-w-0 flex-1">
+            <span className="block leading-tight">{a.label}</span>
+            {a.description && (
+              <span className="mt-0.5 block font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+                {a.description}
+              </span>
+            )}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ObstacleSwatch({ kind }: { kind: ObstacleKind }) {
+  const color =
+    kind === "tree"
+      ? "#5d8055"
+      : kind === "rock"
+        ? "#8a8474"
+        : kind === "cactus"
+          ? "#7aa05c"
+          : kind === "bush"
+            ? "#6b9a55"
+            : "#d96846";
+  return (
+    <span
+      aria-hidden
+      className="h-2.5 w-2.5 shrink-0 rounded-sm border border-[var(--color-border-strong)]"
+      style={{ background: color }}
+    />
+  );
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  if (v < lo) return lo;
+  if (v > hi) return hi;
+  return v;
+}

--- a/components/hud/HUD.tsx
+++ b/components/hud/HUD.tsx
@@ -18,6 +18,16 @@ import { RESOURCES, type ResourceKind } from "@/content/resources";
 import { globalToLocal } from "@/lib/sim/biome-interior";
 import type { GameOverReason } from "@/lib/sim/world";
 import { findFaction } from "@/lib/sim/faction";
+import {
+  inventoryCapFromBaskets,
+  inventoryTotal,
+} from "@/lib/sim/inventory";
+import {
+  basketCount,
+  TOOLS,
+  type ToolInstance,
+  type ToolKind,
+} from "@/lib/sim/tools";
 
 const SPEEDS = [1, 2, 4] as const;
 
@@ -164,7 +174,11 @@ export default function HUD() {
         <div className="pointer-events-none absolute inset-x-2 top-16 z-10 flex flex-wrap items-center justify-end gap-2">
           <HealthStrip health={player.health} max={player.healthMax} inCombat={inCombat} />
           <EnergyStrip energy={player.energy} max={player.energyMax} />
-          <InventoryStrip inventory={inventory} onOpen={openInventory} />
+          <InventoryStrip
+            inventory={inventory}
+            tools={player.tools}
+            onOpen={openInventory}
+          />
         </div>
       )}
 
@@ -361,38 +375,138 @@ function EnergyStrip({ energy, max }: { energy: number; max: number }) {
 
 function InventoryStrip({
   inventory,
+  tools,
   onOpen,
 }: {
   inventory: Partial<Record<ResourceKind, number>>;
+  tools: ToolInstance[];
   onOpen: () => void;
 }) {
   const entries = (Object.entries(inventory) as Array<[ResourceKind, number]>).filter(
     ([, n]) => n > 0,
   );
+  const cap = inventoryCapFromBaskets(basketCount(tools));
+  const total = inventoryTotal(inventory);
+  const grouped = groupTools(tools);
   return (
     <button
       onClick={onOpen}
       aria-label="Open inventory"
-      className="tactile pointer-events-auto inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
+      className="tactile pointer-events-auto inline-flex flex-col items-stretch gap-1 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1.5 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
     >
-      {entries.length === 0 ? (
-        <span className="font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
-          Inventory
+      <span className="inline-flex items-center gap-2">
+        <span className="font-mono text-[10px] uppercase tracking-wider tabular-nums text-[var(--color-fg-muted)]">
+          {total}/{cap}
         </span>
-      ) : (
-        entries.map(([kind, count]) => (
-          <span key={kind} className="inline-flex items-center gap-1">
-            <span
-              aria-hidden
-              className="h-2.5 w-2.5 rounded-full border border-[var(--color-border-strong)]"
-              style={{ background: RESOURCES[kind].swatch }}
-            />
-            <span className="font-mono text-[10px] tabular-nums text-[var(--color-fg)]">
-              {count}
-            </span>
+        {entries.length === 0 ? (
+          <span className="font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+            empty
           </span>
-        ))
+        ) : (
+          entries.map(([kind, count]) => (
+            <span key={kind} className="inline-flex items-center gap-1">
+              <span
+                aria-hidden
+                className="h-2.5 w-2.5 rounded-full border border-[var(--color-border-strong)]"
+                style={{ background: RESOURCES[kind].swatch }}
+              />
+              <span className="font-mono text-[10px] tabular-nums text-[var(--color-fg)]">
+                {count}
+              </span>
+            </span>
+          ))
+        )}
+      </span>
+      {grouped.length > 0 && (
+        <span className="inline-flex items-center gap-1.5 border-t border-[var(--color-border)] pt-1">
+          {grouped.map((g) => (
+            <ToolBadge key={g.kind} kind={g.kind} count={g.count} fraction={g.fraction} />
+          ))}
+        </span>
       )}
     </button>
+  );
+}
+
+type ToolGroup = { kind: ToolKind; count: number; fraction: number };
+
+function groupTools(tools: ToolInstance[]): ToolGroup[] {
+  const map = new Map<ToolKind, { count: number; minFraction: number }>();
+  for (const t of tools) {
+    const meta = TOOLS[t.kind];
+    const fraction = meta.durability > 0 ? Math.max(0, t.usesLeft) / meta.durability : 1;
+    const cur = map.get(t.kind);
+    if (cur) {
+      cur.count += 1;
+      if (fraction < cur.minFraction) cur.minFraction = fraction;
+    } else {
+      map.set(t.kind, { count: 1, minFraction: fraction });
+    }
+  }
+  const out: ToolGroup[] = [];
+  for (const [kind, v] of map) {
+    out.push({ kind, count: v.count, fraction: v.minFraction });
+  }
+  return out;
+}
+
+function ToolBadge({
+  kind,
+  count,
+  fraction,
+}: {
+  kind: ToolKind;
+  count: number;
+  fraction: number;
+}) {
+  const meta = TOOLS[kind];
+  const f = Math.max(0, Math.min(1, fraction));
+  const r = 8;
+  const c = 2 * Math.PI * r;
+  const dash = c * f;
+  const showRing = meta.durability < 999;
+  return (
+    <span
+      aria-label={`${meta.label} ×${count}`}
+      className="relative inline-flex h-5 w-5 items-center justify-center"
+    >
+      {showRing && (
+        <svg
+          viewBox="0 0 20 20"
+          className="absolute inset-0"
+          aria-hidden
+        >
+          <circle
+            cx="10"
+            cy="10"
+            r={r}
+            fill="none"
+            stroke="var(--color-border)"
+            strokeWidth="1.5"
+          />
+          <circle
+            cx="10"
+            cy="10"
+            r={r}
+            fill="none"
+            stroke="var(--color-accent)"
+            strokeWidth="1.5"
+            strokeDasharray={`${dash} ${c}`}
+            strokeLinecap="round"
+            transform="rotate(-90 10 10)"
+          />
+        </svg>
+      )}
+      <span
+        aria-hidden
+        className="relative h-3 w-3 rounded-sm border border-[var(--color-border-strong)]"
+        style={{ background: meta.swatch }}
+      />
+      {count > 1 && (
+        <span className="absolute -bottom-1 -right-1 inline-flex min-w-3 items-center justify-center rounded-full bg-[var(--color-fg)] px-1 font-mono text-[8px] font-medium leading-none text-[var(--color-bg)]">
+          ×{count}
+        </span>
+      )}
+    </span>
   );
 }

--- a/components/panels/InventoryPanel.tsx
+++ b/components/panels/InventoryPanel.tsx
@@ -3,18 +3,18 @@
 import { ForkKnife, Hammer, Knife, Package, X } from "@phosphor-icons/react/dist/ssr";
 import { useGameStore } from "@/lib/state/game-store";
 import { RESOURCES, type ResourceKind } from "@/content/resources";
-import {
-  WEAPONS,
-  WEAPON_KINDS,
-  type WeaponKind,
-} from "@/content/weapons";
+import { WEAPONS } from "@/content/weapons";
+import { TOOLS } from "@/lib/sim/tools";
+import { RECIPES } from "@/content/recipes";
 import { affordable } from "@/lib/sim/weapons";
+import { inventoryCapFromBaskets, inventoryTotal } from "@/lib/sim/inventory";
+import { basketCount } from "@/lib/sim/tools";
 
 export default function InventoryPanel() {
   const open = useGameStore((s) => s.inventoryOpen);
   const close = useGameStore((s) => s.closeInventory);
   const world = useGameStore((s) => s.world);
-  const craft = useGameStore((s) => s.craft);
+  const craftRecipe = useGameStore((s) => s.craftRecipe);
   const eatFood = useGameStore((s) => s.eatFood);
 
   if (!open || !world) return null;
@@ -24,6 +24,9 @@ export default function InventoryPanel() {
   const entries = (Object.entries(inventory) as Array<[ResourceKind, number]>).filter(
     ([, n]) => n > 0,
   );
+  const cap = player ? inventoryCapFromBaskets(basketCount(player.tools)) : 20;
+  const total = inventoryTotal(inventory);
+  const handRecipes = RECIPES.filter((r) => r.station === "hand");
 
   return (
     <aside
@@ -45,7 +48,7 @@ export default function InventoryPanel() {
                 Inventory
               </h2>
               <p className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
-                What you carry
+                <span className="tabular-nums">{total}</span>/<span className="tabular-nums">{cap}</span> · what you carry
               </p>
             </div>
           </div>
@@ -140,18 +143,54 @@ export default function InventoryPanel() {
           </section>
         )}
 
+        {player && player.tools.length > 0 && (
+          <section className="mt-5 border-t border-[var(--color-border)] pt-4">
+            <h3 className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+              Tools
+            </h3>
+            <ul className="mt-3 flex flex-col gap-2">
+              {player.tools.map((t, i) => {
+                const meta = TOOLS[t.kind];
+                return (
+                  <li
+                    key={`${t.kind}-${i}`}
+                    className="flex items-center gap-3 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-warm)] px-3 py-2"
+                  >
+                    <span
+                      aria-hidden
+                      className="h-3.5 w-3.5 shrink-0 rounded-sm border border-[var(--color-border-strong)]"
+                      style={{ background: meta.swatch }}
+                    />
+                    <span className="flex-1 text-sm text-[var(--color-fg)]">
+                      {meta.label}
+                    </span>
+                    <span className="font-mono text-[11px] tabular-nums text-[var(--color-fg-muted)]">
+                      {t.usesLeft >= 999 ? "—" : `${t.usesLeft}/${meta.durability}`}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        )}
+
         <section className="mt-5 border-t border-[var(--color-border)] pt-4">
           <h3 className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
-            Crafting
+            Quick craft
           </h3>
           <ul className="mt-3 flex flex-col gap-2">
-            {WEAPON_KINDS.map((kind: WeaponKind) => {
-              const meta = WEAPONS[kind];
-              const can = Boolean(player) && !world.gameOver && affordable(inventory, kind);
+            {handRecipes.map((recipe) => {
+              const meta = WEAPONS[
+                recipe.result.kind === "weapon" ? recipe.result.id : "stick"
+              ];
+              const can =
+                Boolean(player) &&
+                !world.gameOver &&
+                affordable(inventory, recipe);
               return (
-                <li key={kind}>
+                <li key={recipe.id}>
                   <button
-                    onClick={() => craft(kind)}
+                    onClick={() => craftRecipe(recipe.id)}
                     disabled={!can}
                     className="tactile flex w-full items-center gap-3 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-warm)] px-3 py-2 text-left disabled:cursor-not-allowed disabled:opacity-60"
                   >
@@ -162,7 +201,7 @@ export default function InventoryPanel() {
                     />
                     <span className="flex-1">
                       <span className="block text-sm font-medium text-[var(--color-fg)]">
-                        {meta.label}
+                        {recipe.name}
                       </span>
                       <span className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
                         <span>+{meta.attack} atk</span>
@@ -171,7 +210,7 @@ export default function InventoryPanel() {
                         <span>· uses {meta.durability}</span>
                       </span>
                       <span className="mt-1 flex flex-wrap gap-1.5">
-                        {(Object.entries(meta.recipe) as Array<[
+                        {(Object.entries(recipe.inputs) as Array<[
                           ResourceKind,
                           number,
                         ]>).map(([k, n]) => (
@@ -193,10 +232,11 @@ export default function InventoryPanel() {
 
         <section className="mt-5 border-t border-[var(--color-border)] pt-4">
           <h3 className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
-            Gear (coming soon)
+            More at the workbench
           </h3>
           <p className="mt-2 text-sm text-[var(--color-fg-muted)]">
-            Tools, armour, and trinkets land with the workbench in Phase 4.
+            Tap the workbench at home to craft tools (axe, pickaxe, basket,
+            torch) and advanced weapons (sword, bow).
           </p>
         </section>
       </div>
@@ -228,3 +268,4 @@ function RecipePip({
     </span>
   );
 }
+

--- a/components/panels/RegionPanel.tsx
+++ b/components/panels/RegionPanel.tsx
@@ -5,8 +5,8 @@ import { useGameStore, WALK_MAX_RADIUS } from "@/lib/state/game-store";
 import { biomeAt } from "@/lib/sim/biome";
 import { BIOMES } from "@/content/biomes";
 import { FACTIONS } from "@/content/factions";
-import { BIOME_RESOURCES, RESOURCES } from "@/content/resources";
-import { globalToLocal, regionCenterGlobal } from "@/lib/sim/biome-interior";
+import { BIOME_RESOURCES, RESOURCES, type ResourceKind } from "@/content/resources";
+import { globalToLocal, regionCenterGlobal, regionKey } from "@/lib/sim/biome-interior";
 
 export default function RegionPanel() {
   const region = useGameStore((s) => s.selectedRegion);
@@ -107,6 +107,8 @@ export default function RegionPanel() {
             ))}
           </p>
         )}
+
+        <ResourcesHere world={world} rx={region.rx} ry={region.ry} />
 
         {canClaim && (
           <button
@@ -211,4 +213,43 @@ function factionHex(color: number): string {
 
 function factionLabel(id: string): string {
   return FACTIONS.find((f) => f.id === id)?.name ?? id;
+}
+
+function ResourcesHere({
+  world,
+  rx,
+  ry,
+}: {
+  world: { biomeInteriors: Record<string, import("@/lib/sim/biome-interior").BiomeInterior> };
+  rx: number;
+  ry: number;
+}) {
+  const interior = world.biomeInteriors[regionKey(rx, ry)];
+  if (!interior) return null;
+  const counts: Partial<Record<ResourceKind, number>> = {};
+  for (const r of interior.resources) {
+    counts[r.kind] = (counts[r.kind] ?? 0) + 1;
+  }
+  const entries = (Object.entries(counts) as Array<[ResourceKind, number]>).filter(
+    ([, n]) => n > 0,
+  );
+  if (entries.length === 0) return null;
+  return (
+    <p className="mt-3 flex flex-wrap items-center gap-2 font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+      Resources here
+      {entries.map(([kind, n]) => (
+        <span key={kind} className="inline-flex items-center gap-1.5 normal-case">
+          <span
+            aria-hidden
+            className="h-2.5 w-2.5 rounded-full border border-[var(--color-border-strong)]"
+            style={{ background: RESOURCES[kind].swatch }}
+          />
+          <span className="text-[var(--color-fg)]">
+            {RESOURCES[kind].label}{" "}
+            <span className="tabular-nums text-[var(--color-fg-muted)]">×{n}</span>
+          </span>
+        </span>
+      ))}
+    </p>
+  );
 }

--- a/components/panels/WorkbenchPanel.tsx
+++ b/components/panels/WorkbenchPanel.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { Hammer, X } from "@phosphor-icons/react/dist/ssr";
+import { useGameStore } from "@/lib/state/game-store";
+import { RESOURCES, type ResourceKind } from "@/content/resources";
+import { WEAPONS } from "@/content/weapons";
+import { TOOLS } from "@/lib/sim/tools";
+import { RECIPES, type Recipe } from "@/content/recipes";
+import { affordable } from "@/lib/sim/weapons";
+import {
+  findWorkbenchTile,
+  globalToLocal,
+  regionKey,
+} from "@/lib/sim/biome-interior";
+import { chebyshev } from "@/lib/sim/combat";
+
+export default function WorkbenchPanel() {
+  const open = useGameStore((s) => s.workbenchOpen);
+  const close = useGameStore((s) => s.closeWorkbench);
+  const world = useGameStore((s) => s.world);
+  const craftRecipe = useGameStore((s) => s.craftRecipe);
+
+  if (!open || !world?.player) return null;
+
+  const recipes = RECIPES.filter((r) => r.station === "workbench");
+  const inventory = world.inventory;
+  const player = world.player;
+  const here = globalToLocal(player.gx, player.gy);
+  const interior = world.biomeInteriors[regionKey(here.rx, here.ry)];
+  const wb = interior ? findWorkbenchTile(interior) : null;
+  const adjacent = wb ? chebyshev(here.lx, here.ly, wb.lx, wb.ly) <= 1 : false;
+
+  return (
+    <aside
+      role="dialog"
+      aria-label="Workbench"
+      className="pointer-events-auto absolute inset-x-2 bottom-2 z-20 max-h-[68dvh] overflow-y-auto rounded-3xl border border-[var(--color-border)] bg-[var(--color-surface)] p-5 shadow-[0_20px_48px_-20px_rgba(44,40,32,0.25)]"
+    >
+      <div className="mx-auto max-w-2xl">
+        <header className="mb-4 flex items-start justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <span
+              aria-hidden
+              className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--color-border-strong)]"
+              style={{ background: "var(--color-accent)" }}
+            >
+              <Hammer size={18} weight="fill" className="text-[var(--color-bg)]" />
+            </span>
+            <div>
+              <h2 className="text-lg font-medium leading-tight text-[var(--color-fg)]">
+                Workbench
+              </h2>
+              <p className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+                {adjacent ? "Tap a recipe to craft" : "Walk closer to craft"}
+              </p>
+            </div>
+          </div>
+          <button
+            aria-label="Close"
+            onClick={close}
+            className="tactile inline-flex h-9 w-9 items-center justify-center rounded-full text-[var(--color-fg-muted)] hover:bg-[var(--color-surface-warm)] hover:text-[var(--color-fg)]"
+          >
+            <X size={18} weight="bold" />
+          </button>
+        </header>
+
+        <ul className="flex flex-col gap-2">
+          {recipes.map((recipe) => (
+            <RecipeRow
+              key={recipe.id}
+              recipe={recipe}
+              inventory={inventory}
+              adjacent={adjacent}
+              gameOver={world.gameOver}
+              onCraft={() => craftRecipe(recipe.id)}
+            />
+          ))}
+        </ul>
+      </div>
+    </aside>
+  );
+}
+
+function RecipeRow({
+  recipe,
+  inventory,
+  adjacent,
+  gameOver,
+  onCraft,
+}: {
+  recipe: Recipe;
+  inventory: Partial<Record<ResourceKind, number>>;
+  adjacent: boolean;
+  gameOver: boolean;
+  onCraft: () => void;
+}) {
+  const can = adjacent && !gameOver && affordable(inventory, recipe);
+  const stats = describeResult(recipe);
+  return (
+    <li>
+      <button
+        onClick={onCraft}
+        disabled={!can}
+        className="tactile flex w-full items-center gap-3 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-warm)] px-3 py-2 text-left disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <Hammer
+          size={16}
+          weight={can ? "fill" : "regular"}
+          className="shrink-0 text-[var(--color-accent)]"
+        />
+        <span className="flex-1">
+          <span className="block text-sm font-medium text-[var(--color-fg)]">
+            {recipe.name}
+          </span>
+          <span className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+            {stats.map((s) => (
+              <span key={s}>{s}</span>
+            ))}
+            {recipe.time > 0 && <span>· {recipe.time} ticks</span>}
+          </span>
+          <span className="mt-1 flex flex-wrap gap-1.5">
+            {(Object.entries(recipe.inputs) as Array<[ResourceKind, number]>).map(
+              ([k, n]) => (
+                <RecipePip
+                  key={k}
+                  kind={k}
+                  need={n}
+                  have={inventory[k] ?? 0}
+                />
+              ),
+            )}
+          </span>
+        </span>
+      </button>
+    </li>
+  );
+}
+
+function describeResult(recipe: Recipe): string[] {
+  if (recipe.result.kind === "weapon") {
+    const meta = WEAPONS[recipe.result.id];
+    const out = [`+${meta.attack} atk`, `reach ${meta.reach}`];
+    if (meta.ranged) out.push("ranged");
+    out.push(`uses ${meta.durability}`);
+    return out;
+  }
+  const meta = TOOLS[recipe.result.id];
+  if (recipe.result.id === "basket") {
+    return ["+20 inventory cap"];
+  }
+  if (recipe.result.id === "torch") {
+    return ["+3 sight (Phase 6)"];
+  }
+  return [`uses ${meta.durability}`];
+}
+
+function RecipePip({
+  kind,
+  need,
+  have,
+}: {
+  kind: ResourceKind;
+  need: number;
+  have: number;
+}) {
+  const ok = have >= need;
+  return (
+    <span
+      className="inline-flex items-center gap-1 font-mono text-[10px] tabular-nums"
+      style={{ color: ok ? "var(--color-fg)" : "var(--color-fg-muted)" }}
+    >
+      <span
+        aria-hidden
+        className="h-2 w-2 rounded-full border border-[var(--color-border-strong)]"
+        style={{ background: RESOURCES[kind].swatch }}
+      />
+      {RESOURCES[kind].label} {have}/{need}
+    </span>
+  );
+}

--- a/content/recipes.ts
+++ b/content/recipes.ts
@@ -1,0 +1,96 @@
+import type { ResourceKind } from "@/content/resources";
+import type { WeaponKind } from "@/content/weapons";
+import type { ToolKind } from "@/lib/sim/tools";
+
+export type RecipeStation = "hand" | "workbench";
+
+export type RecipeResult =
+  | { kind: "weapon"; id: WeaponKind }
+  | { kind: "tool"; id: ToolKind };
+
+export type Recipe = {
+  id: string;
+  name: string;
+  result: RecipeResult;
+  inputs: Partial<Record<ResourceKind, number>>;
+  time: number;
+  station: RecipeStation;
+};
+
+export const RECIPES: Recipe[] = [
+  {
+    id: "stick",
+    name: "Stick",
+    result: { kind: "weapon", id: "stick" },
+    inputs: { wood: 1 },
+    time: 0,
+    station: "hand",
+  },
+  {
+    id: "club",
+    name: "Club",
+    result: { kind: "weapon", id: "club" },
+    inputs: { wood: 2, stone: 1 },
+    time: 0,
+    station: "hand",
+  },
+  {
+    id: "sling",
+    name: "Sling",
+    result: { kind: "weapon", id: "sling" },
+    inputs: { reed: 2, stone: 1 },
+    time: 0,
+    station: "hand",
+  },
+  {
+    id: "axe",
+    name: "Axe",
+    result: { kind: "tool", id: "axe" },
+    inputs: { wood: 2, stone: 1 },
+    time: 4,
+    station: "workbench",
+  },
+  {
+    id: "pickaxe",
+    name: "Pickaxe",
+    result: { kind: "tool", id: "pickaxe" },
+    inputs: { wood: 1, stone: 2 },
+    time: 4,
+    station: "workbench",
+  },
+  {
+    id: "basket",
+    name: "Basket",
+    result: { kind: "tool", id: "basket" },
+    inputs: { reed: 3 },
+    time: 3,
+    station: "workbench",
+  },
+  {
+    id: "torch",
+    name: "Torch",
+    result: { kind: "tool", id: "torch" },
+    inputs: { wood: 1, herb: 1 },
+    time: 2,
+    station: "workbench",
+  },
+  {
+    id: "sword",
+    name: "Sword",
+    result: { kind: "weapon", id: "sword" },
+    inputs: { wood: 2, ore: 3 },
+    time: 6,
+    station: "workbench",
+  },
+  {
+    id: "bow",
+    name: "Bow",
+    result: { kind: "weapon", id: "bow" },
+    inputs: { wood: 3, reed: 2 },
+    time: 5,
+    station: "workbench",
+  },
+];
+
+export const RECIPES_BY_ID: Record<string, Recipe> = {};
+for (const r of RECIPES) RECIPES_BY_ID[r.id] = r;

--- a/content/weapons.ts
+++ b/content/weapons.ts
@@ -1,6 +1,4 @@
-import type { ResourceKind } from "@/content/resources";
-
-export type WeaponKind = "stick" | "club" | "sling";
+export type WeaponKind = "stick" | "club" | "sling" | "sword" | "bow";
 
 export type WeaponMeta = {
   label: string;
@@ -8,7 +6,6 @@ export type WeaponMeta = {
   reach: number;
   durability: number;
   ranged: boolean;
-  recipe: Partial<Record<ResourceKind, number>>;
   swatch: string;
 };
 
@@ -19,7 +16,6 @@ export const WEAPONS: Record<WeaponKind, WeaponMeta> = {
     reach: 1,
     durability: 8,
     ranged: false,
-    recipe: { wood: 1 },
     swatch: "#8a6a4a",
   },
   club: {
@@ -28,7 +24,6 @@ export const WEAPONS: Record<WeaponKind, WeaponMeta> = {
     reach: 1,
     durability: 12,
     ranged: false,
-    recipe: { wood: 2, stone: 1 },
     swatch: "#7a5a3a",
   },
   sling: {
@@ -37,9 +32,24 @@ export const WEAPONS: Record<WeaponKind, WeaponMeta> = {
     reach: 4,
     durability: 6,
     ranged: true,
-    recipe: { reed: 2, stone: 1 },
     swatch: "#a8b878",
+  },
+  sword: {
+    label: "Sword",
+    attack: 3,
+    reach: 1,
+    durability: 30,
+    ranged: false,
+    swatch: "#9aa4b6",
+  },
+  bow: {
+    label: "Bow",
+    attack: 2,
+    reach: 5,
+    durability: 25,
+    ranged: true,
+    swatch: "#b48c5e",
   },
 };
 
-export const WEAPON_KINDS: WeaponKind[] = ["stick", "club", "sling"];
+export const WEAPON_KINDS: WeaponKind[] = ["stick", "club", "sling", "sword", "bow"];

--- a/lib/render/scenes/BiomeScene.ts
+++ b/lib/render/scenes/BiomeScene.ts
@@ -4,9 +4,10 @@ import {
   globalToLocal,
   INTERIOR_W,
   INTERIOR_H,
-  isLocalObstacle,
+  obstacleKindAt,
   regionKey,
   type BiomeInterior,
+  type ObstacleKind,
 } from "@/lib/sim/biome-interior";
 import { biomeAt, blendNoise, type Biome } from "@/lib/sim/biome";
 import { BIOMES } from "@/content/biomes";
@@ -42,6 +43,8 @@ const COLORS = {
   rockShade: 0x67625a,
   bush: 0x86a06d,
   cactus: 0x7e9b6a,
+  workbench: 0xd96846,
+  workbenchLeg: 0x7a3d28,
 };
 
 type VisitorView = {
@@ -387,8 +390,9 @@ export class BiomeScene extends Phaser.Scene {
         const py = gy * CELL;
         this.tileLayer.fillStyle(color, 1);
         this.tileLayer.fillRect(px, py, CELL, CELL);
-        if (interior && biome !== "water" && isLocalObstacle(interior, lx, ly)) {
-          this.drawObstacle(biome, gx, gy);
+        if (interior && biome !== "water") {
+          const kind = obstacleKindAt(interior, lx, ly);
+          if (kind) this.drawObstacle(kind, gx, gy);
         }
       }
     }
@@ -403,12 +407,12 @@ export class BiomeScene extends Phaser.Scene {
     return color;
   }
 
-  private drawObstacle(biome: Biome, gx: number, gy: number) {
+  private drawObstacle(kind: ObstacleKind, gx: number, gy: number) {
     const cx = gx * CELL + CELL / 2;
     const cy = gy * CELL + CELL / 2;
-    switch (biome) {
-      case "forest":
-        // Tree: small brown trunk + green canopy triangle.
+    switch (kind) {
+      case "tree":
+        // Small brown trunk + green canopy triangle.
         this.tileLayer.fillStyle(COLORS.forestTrunk, 1);
         this.tileLayer.fillRect(cx - 2, cy + 4, 4, 8);
         this.tileLayer.fillStyle(COLORS.forestTree, 1);
@@ -416,8 +420,8 @@ export class BiomeScene extends Phaser.Scene {
         this.tileLayer.fillStyle(COLORS.shadow, 0.18);
         this.tileLayer.fillEllipse(cx, cy + 13, 18, 4);
         break;
-      case "stone": {
-        // Rock: irregular pentagon with a darker shade slice.
+      case "rock": {
+        // Irregular pentagon with a darker shade slice.
         this.tileLayer.fillStyle(COLORS.rock, 1);
         fillPolygon(this.tileLayer, [
           [cx - 11, cy + 6],
@@ -435,8 +439,8 @@ export class BiomeScene extends Phaser.Scene {
         ]);
         break;
       }
-      case "sand":
-        // Cactus: vertical bar with one offshoot.
+      case "cactus":
+        // Vertical bar with one offshoot.
         this.tileLayer.fillStyle(COLORS.cactus, 1);
         this.tileLayer.fillRoundedRect(cx - 3, cy - 12, 6, 24, 2);
         this.tileLayer.fillRoundedRect(cx + 3, cy - 4, 7, 5, 2);
@@ -444,8 +448,8 @@ export class BiomeScene extends Phaser.Scene {
         this.tileLayer.fillStyle(COLORS.shadow, 0.18);
         this.tileLayer.fillEllipse(cx + 1, cy + 13, 14, 4);
         break;
-      case "grass":
-        // Bush: 3 overlapping circles.
+      case "bush":
+        // 3 overlapping circles.
         this.tileLayer.fillStyle(COLORS.shadow, 0.18);
         this.tileLayer.fillEllipse(cx, cy + 9, 16, 4);
         this.tileLayer.fillStyle(COLORS.bush, 1);
@@ -453,7 +457,17 @@ export class BiomeScene extends Phaser.Scene {
         this.tileLayer.fillCircle(cx + 5, cy + 1, 6);
         this.tileLayer.fillCircle(cx, cy - 4, 7);
         break;
-      case "water":
+      case "workbench":
+        // Coral-accent rounded bench top with two stubby legs.
+        this.tileLayer.fillStyle(COLORS.shadow, 0.18);
+        this.tileLayer.fillEllipse(cx, cy + 11, 20, 4);
+        this.tileLayer.fillStyle(COLORS.workbenchLeg, 1);
+        this.tileLayer.fillRect(cx - 8, cy + 4, 3, 6);
+        this.tileLayer.fillRect(cx + 5, cy + 4, 3, 6);
+        this.tileLayer.fillStyle(COLORS.workbench, 1);
+        this.tileLayer.fillRoundedRect(cx - 11, cy - 5, 22, 10, 2);
+        this.tileLayer.fillStyle(COLORS.workbenchLeg, 1);
+        this.tileLayer.fillRect(cx - 9, cy - 1, 18, 1.5);
         break;
     }
   }
@@ -827,13 +841,22 @@ export class BiomeScene extends Phaser.Scene {
     if (!this.dragMoved && dt < 350 && moved < 10) {
       const world = this.cameras.main.getWorldPoint(pointer.x, pointer.y);
       const tappedVisitor = this.hitVisitorAt(world.x, world.y);
+      const store = useGameStore.getState();
       if (tappedVisitor) {
-        useGameStore.getState().openNpcContextMenu(tappedVisitor, pointer.x, pointer.y);
+        store.openNpcContextMenu(tappedVisitor, pointer.x, pointer.y);
       } else {
         const gx = Math.floor(world.x / CELL);
         const gy = Math.floor(world.y / CELL);
-        useGameStore.getState().closeNpcContextMenu();
-        useGameStore.getState().walkPlayerTo(gx, gy);
+        const { rx, ry, lx, ly } = globalToLocal(gx, gy);
+        const interior = store.world?.biomeInteriors[regionKey(rx, ry)];
+        const kind = interior ? obstacleKindAt(interior, lx, ly) : null;
+        store.closeNpcContextMenu();
+        if (kind) {
+          store.openObstacleContextMenu(rx, ry, lx, ly, kind, pointer.x, pointer.y);
+        } else {
+          store.closeObstacleContextMenu();
+          store.walkPlayerTo(gx, gy);
+        }
       }
     }
 

--- a/lib/sim/biome-interior.ts
+++ b/lib/sim/biome-interior.ts
@@ -1,5 +1,5 @@
 import { biomeAt, type Biome } from "@/lib/sim/biome";
-import { createRng } from "@/lib/sim/rng";
+import { createRng, type Rng } from "@/lib/sim/rng";
 import {
   BIOME_RESOURCES,
   RESOURCE_DENSITY,
@@ -9,6 +9,8 @@ import {
 export const INTERIOR_W = 20;
 export const INTERIOR_H = 20;
 export const OBSTACLE_DENSITY = 0.10;
+
+export type ObstacleKind = "tree" | "rock" | "cactus" | "bush" | "workbench";
 
 export type InteriorResource = {
   id: string;
@@ -23,6 +25,7 @@ export type LootPile = {
   ly: number;
   items: Partial<Record<ResourceKind, number>>;
   weapons?: import("@/lib/sim/weapons").WeaponInstance[];
+  tools?: import("@/lib/sim/tools").ToolInstance[];
   // Optional flag: this pile was dropped by the player on death. Lets the
   // render layer show it differently and the encounter feed reference it.
   fromDeath?: boolean;
@@ -32,7 +35,7 @@ export type BiomeInterior = {
   rx: number;
   ry: number;
   biome: Biome;
-  obstacles: boolean[];
+  obstacles: (ObstacleKind | null)[];
   resources: InteriorResource[];
   loot: LootPile[];
 };
@@ -65,6 +68,21 @@ export function regionCenterGlobal(rx: number, ry: number): { gx: number; gy: nu
   return localToGlobal(rx, ry, Math.floor(INTERIOR_W / 2), Math.floor(INTERIOR_H / 2));
 }
 
+export function defaultObstacleKindForBiome(biome: Biome): ObstacleKind | null {
+  switch (biome) {
+    case "forest":
+      return "tree";
+    case "stone":
+      return "rock";
+    case "sand":
+      return "cactus";
+    case "grass":
+      return "bush";
+    case "water":
+      return null;
+  }
+}
+
 // Each region's interior derives from a per-region rng so the generator is
 // reproducible and decoupled from the world's master rng -- the order in
 // which the player visits regions can't desync the rest of the sim.
@@ -78,20 +96,86 @@ export function generateInterior(worldSeed: number, rx: number, ry: number): Bio
       rx,
       ry,
       biome,
-      obstacles: new Array<boolean>(INTERIOR_W * INTERIOR_H).fill(true),
+      obstacles: new Array<ObstacleKind | null>(INTERIOR_W * INTERIOR_H).fill("rock"),
       resources: [],
       loot: [],
     };
   }
 
-  const obstacles = scatterObstacles(rng);
+  const obstacles = scatterObstacles(rng, biome);
   const resources = scatterResources(rng, biome, obstacles);
   return { rx, ry, biome, obstacles, resources, loot: [] };
 }
 
 export function isLocalObstacle(interior: BiomeInterior, lx: number, ly: number): boolean {
   if (lx < 0 || ly < 0 || lx >= INTERIOR_W || ly >= INTERIOR_H) return true;
-  return !!interior.obstacles[ly * INTERIOR_W + lx];
+  return interior.obstacles[ly * INTERIOR_W + lx] != null;
+}
+
+export function obstacleKindAt(
+  interior: BiomeInterior,
+  lx: number,
+  ly: number,
+): ObstacleKind | null {
+  if (lx < 0 || ly < 0 || lx >= INTERIOR_W || ly >= INTERIOR_H) return null;
+  return interior.obstacles[ly * INTERIOR_W + lx] ?? null;
+}
+
+export function clearObstacle(
+  interior: BiomeInterior,
+  lx: number,
+  ly: number,
+): BiomeInterior {
+  if (lx < 0 || ly < 0 || lx >= INTERIOR_W || ly >= INTERIOR_H) return interior;
+  const idx = ly * INTERIOR_W + lx;
+  if (interior.obstacles[idx] == null) return interior;
+  const next = interior.obstacles.slice();
+  next[idx] = null;
+  return { ...interior, obstacles: next };
+}
+
+// Place a workbench on the interior at a passable tile near `near`. Picks
+// from candidates within radius 3 using `rng`, so the choice is deterministic
+// for a given (worldSeed, regionKey, spawn). Returns the original interior
+// when no candidate exists (extremely rare given 10% density).
+export function placeWorkbench(
+  interior: BiomeInterior,
+  near: { lx: number; ly: number },
+  rng: Rng,
+): BiomeInterior {
+  const candidates: Array<{ idx: number; lx: number; ly: number }> = [];
+  for (let r = 1; r <= 3 && candidates.length === 0; r++) {
+    for (let dy = -r; dy <= r; dy++) {
+      for (let dx = -r; dx <= r; dx++) {
+        if (Math.abs(dx) !== r && Math.abs(dy) !== r) continue;
+        const lx = near.lx + dx;
+        const ly = near.ly + dy;
+        if (lx < 0 || ly < 0 || lx >= INTERIOR_W || ly >= INTERIOR_H) continue;
+        const idx = ly * INTERIOR_W + lx;
+        if (interior.obstacles[idx] != null) continue;
+        if (interior.resources.some((res) => res.lx === lx && res.ly === ly)) continue;
+        candidates.push({ idx, lx, ly });
+      }
+    }
+  }
+  if (candidates.length === 0) return interior;
+  const pick = candidates[rng.int(0, candidates.length)]!;
+  const next = interior.obstacles.slice();
+  next[pick.idx] = "workbench";
+  return { ...interior, obstacles: next };
+}
+
+export function findWorkbenchTile(
+  interior: BiomeInterior,
+): { lx: number; ly: number } | null {
+  for (let i = 0; i < interior.obstacles.length; i++) {
+    if (interior.obstacles[i] === "workbench") {
+      const lx = i % INTERIOR_W;
+      const ly = Math.floor(i / INTERIOR_W);
+      return { lx, ly };
+    }
+  }
+  return null;
 }
 
 export function resourceAtLocal(
@@ -153,7 +237,7 @@ export function findPassableTile(
   return null;
 }
 
-function mixSeed(worldSeed: number, rx: number, ry: number): number {
+export function mixSeed(worldSeed: number, rx: number, ry: number): number {
   let h = worldSeed >>> 0;
   h = Math.imul(h ^ rx, 0x9e3779b1);
   h = Math.imul(h ^ ry, 0x85ebca77);
@@ -161,10 +245,12 @@ function mixSeed(worldSeed: number, rx: number, ry: number): number {
   return h >>> 0;
 }
 
-function scatterObstacles(rng: ReturnType<typeof createRng>): boolean[] {
+function scatterObstacles(rng: Rng, biome: Biome): (ObstacleKind | null)[] {
   const cells = INTERIOR_W * INTERIOR_H;
   const target = Math.floor(cells * OBSTACLE_DENSITY);
-  const obstacles = new Array<boolean>(cells).fill(false);
+  const obstacles = new Array<ObstacleKind | null>(cells).fill(null);
+  const kind = defaultObstacleKindForBiome(biome);
+  if (!kind) return obstacles;
   let placed = 0;
   let attempts = 0;
   while (placed < target && attempts < cells * 4) {
@@ -173,16 +259,16 @@ function scatterObstacles(rng: ReturnType<typeof createRng>): boolean[] {
     const ly = rng.int(0, INTERIOR_H);
     const idx = ly * INTERIOR_W + lx;
     if (obstacles[idx]) continue;
-    obstacles[idx] = true;
+    obstacles[idx] = kind;
     placed++;
   }
   return obstacles;
 }
 
 function scatterResources(
-  rng: ReturnType<typeof createRng>,
+  rng: Rng,
   biome: Biome,
-  obstacles: boolean[],
+  obstacles: (ObstacleKind | null)[],
 ): InteriorResource[] {
   const lists = BIOME_RESOURCES[biome];
   const density = RESOURCE_DENSITY[biome];

--- a/lib/sim/combat.ts
+++ b/lib/sim/combat.ts
@@ -291,7 +291,7 @@ function stepTowardTarget(
   const interiorPos = npc.interior!;
 
   // Build occupancy grid for BFS + random-walk obstacle checks.
-  const occupied: boolean[] = interior.obstacles.slice();
+  const occupied: boolean[] = interior.obstacles.map((o) => o != null);
   occupied[here.ly * INTERIOR_W + here.lx] = true;
   for (const j of inHere) {
     if (j === selfIdx) continue;

--- a/lib/sim/inventory.ts
+++ b/lib/sim/inventory.ts
@@ -1,3 +1,33 @@
 import type { ResourceKind } from "@/content/resources";
 
 export type Inventory = Partial<Record<ResourceKind, number>>;
+
+export const BASE_INVENTORY_CAP = 20;
+export const PER_BASKET_BONUS = 20;
+export const MAX_INVENTORY_CAP = 80;
+
+export function inventoryTotal(inv: Inventory): number {
+  let total = 0;
+  for (const k of Object.keys(inv) as ResourceKind[]) {
+    total += inv[k] ?? 0;
+  }
+  return total;
+}
+
+export function inventoryCapFromBaskets(baskets: number): number {
+  return Math.min(MAX_INVENTORY_CAP, BASE_INVENTORY_CAP + PER_BASKET_BONUS * baskets);
+}
+
+export function addToInventory(
+  inv: Inventory,
+  kind: ResourceKind,
+  amount: number,
+  cap: number,
+): { inv: Inventory; added: number } {
+  if (amount <= 0) return { inv, added: 0 };
+  const total = inventoryTotal(inv);
+  const remaining = Math.max(0, cap - total);
+  const added = Math.min(amount, remaining);
+  if (added <= 0) return { inv, added: 0 };
+  return { inv: { ...inv, [kind]: (inv[kind] ?? 0) + added }, added };
+}

--- a/lib/sim/player-tick.ts
+++ b/lib/sim/player-tick.ts
@@ -15,14 +15,27 @@ import {
   regionKey,
   removeResource,
   resourceAtLocal,
+  obstacleKindAt,
+  clearObstacle,
   type BiomeInterior,
+  type ObstacleKind,
 } from "@/lib/sim/biome-interior";
-import type { Inventory } from "@/lib/sim/inventory";
+import {
+  addToInventory,
+  inventoryCapFromBaskets,
+  type Inventory,
+} from "@/lib/sim/inventory";
 import type { ResourceKind } from "@/content/resources";
 import type { Npc } from "@/lib/sim/npc";
 import { applyRepPenalty, resolvePlayerAttack, chebyshev } from "@/lib/sim/combat";
 import { pickWeaponForRange, weaponReach } from "@/lib/sim/weapons";
 import { bfs } from "@/lib/sim/path";
+import {
+  basketCount,
+  consumeToolUse,
+  hasTool,
+  type ToolKind,
+} from "@/lib/sim/tools";
 import type { Rng } from "@/lib/sim/rng";
 
 export type PickupNotice = {
@@ -56,6 +69,7 @@ export type PlayerTickOutput = {
   pickups: PickupNotice[];
   projectiles: ProjectileNotice[];
   death: boolean;
+  workbenchOpened: boolean;
 };
 
 export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
@@ -64,6 +78,7 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
   const ticks = input.ticks;
   const pickups: PickupNotice[] = [];
   const projectiles: ProjectileNotice[] = [];
+  let workbenchOpened = false;
 
   if (player.combatCooldown > 0) {
     player = { ...player, combatCooldown: player.combatCooldown - 1 };
@@ -152,6 +167,22 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
       interiors = result.interiors;
       inventory = result.inventory;
       if (result.pickup) pickups.push(result.pickup);
+    } else if (action.kind === "harvest") {
+      const result = tryHarvest(player, interiors, inventory, action, rng);
+      player = result.player;
+      interiors = result.interiors;
+      inventory = result.inventory;
+      if (result.pickup) pickups.push(result.pickup);
+    } else if (action.kind === "workbench") {
+      const here = globalToLocal(player.gx, player.gy);
+      if (
+        here.rx === action.rx &&
+        here.ry === action.ry &&
+        chebyshev(here.lx, here.ly, action.lx, action.ly) <= 1
+      ) {
+        workbenchOpened = true;
+      }
+      player = { ...player, pendingAction: null };
     } else if (action.kind === "attack") {
       const targetIdx = npcs.findIndex((n) => n.id === action.npcId);
       if (targetIdx >= 0) {
@@ -220,6 +251,7 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
     pickups,
     projectiles,
     death: player.health <= 0,
+    workbenchOpened,
   };
 }
 
@@ -265,7 +297,7 @@ function chasePlan(
   }
 
   // BFS over the interior obstacles, treating other NPC tiles as blocked.
-  const occupied = interior.obstacles.slice();
+  const occupied = obstacleBoolGrid(interior);
   // Block other NPC tiles so we don't try to walk through them.
   // (We don't have full npcs here; the route walker treats live obstacle
   // collisions as a hard stop separately.)
@@ -318,18 +350,81 @@ function tryCollect(
     return { player, interiors, inventory, pickup: null };
   }
 
+  const cap = inventoryCapFromBaskets(basketCount(player.tools));
+  const added = addToInventory(inventory, resource.kind, 1, cap);
+  if (added.added <= 0) {
+    // Inventory full — leave the resource on the ground.
+    return { player, interiors, inventory, pickup: null };
+  }
   const updatedInterior = removeResource(interior, resource.id);
   const updatedInteriors = { ...interiors, [regionKey(rx, ry)]: updatedInterior };
-  const updatedInventory: Inventory = {
-    ...inventory,
-    [resource.kind]: (inventory[resource.kind] ?? 0) + 1,
-  };
 
   return {
     player,
     interiors: updatedInteriors,
-    inventory: updatedInventory,
-    pickup: { kind: resource.kind, amount: 1 },
+    inventory: added.inv,
+    pickup: { kind: resource.kind, amount: added.added },
+  };
+}
+
+function tryHarvest(
+  player: Player,
+  interiors: Record<string, BiomeInterior>,
+  inventory: Inventory,
+  action: Extract<PendingAction, { kind: "harvest" }>,
+  rng: Rng,
+): {
+  player: Player;
+  interiors: Record<string, BiomeInterior>;
+  inventory: Inventory;
+  pickup: PickupNotice | null;
+} {
+  let nextPlayer: Player = { ...player, pendingAction: null };
+  const here = globalToLocal(player.gx, player.gy);
+  if (here.rx !== action.rx || here.ry !== action.ry) {
+    return { player: nextPlayer, interiors, inventory, pickup: null };
+  }
+  if (chebyshev(here.lx, here.ly, action.lx, action.ly) > 1) {
+    return { player: nextPlayer, interiors, inventory, pickup: null };
+  }
+  const k = regionKey(action.rx, action.ry);
+  const interior = interiors[k];
+  if (!interior) return { player: nextPlayer, interiors, inventory, pickup: null };
+  const stillThere = obstacleKindAt(interior, action.lx, action.ly);
+  if (stillThere !== action.obstacle) {
+    return { player: nextPlayer, interiors, inventory, pickup: null };
+  }
+
+  let toolKind: ToolKind | null = null;
+  let drop: ResourceKind | null = null;
+  if (action.obstacle === "tree") {
+    toolKind = "axe";
+    drop = "wood";
+  } else if (action.obstacle === "rock") {
+    toolKind = "pickaxe";
+    drop = interior.biome === "stone" && rng.chance(0.25) ? "ore" : "stone";
+  } else {
+    // Cactus, bush, workbench: nothing to harvest.
+    return { player: nextPlayer, interiors, inventory, pickup: null };
+  }
+  if (!hasTool(nextPlayer.tools, toolKind)) {
+    return { player: nextPlayer, interiors, inventory, pickup: null };
+  }
+
+  const cap = inventoryCapFromBaskets(basketCount(nextPlayer.tools));
+  const added = addToInventory(inventory, drop, 1, cap);
+  if (added.added <= 0) {
+    return { player: nextPlayer, interiors, inventory, pickup: null };
+  }
+  nextPlayer = { ...nextPlayer, tools: consumeToolUse(nextPlayer.tools, toolKind) };
+  const updatedInterior = clearObstacle(interior, action.lx, action.ly);
+  const updatedInteriors = { ...interiors, [k]: updatedInterior };
+
+  return {
+    player: nextPlayer,
+    interiors: updatedInteriors,
+    inventory: added.inv,
+    pickup: { kind: drop, amount: added.added },
   };
 }
 
@@ -349,17 +444,22 @@ function pickupLoot(
   if (!interior) return { player, interiors, inventory, pickups: [] };
   const pile = lootAtLocal(interior, lx, ly);
   if (!pile) return { player, interiors, inventory, pickups: [] };
-  const nextInventory: Inventory = { ...inventory };
+  let nextInventory: Inventory = inventory;
   const pickups: PickupNotice[] = [];
+  let nextPlayer = player;
+  if (pile.tools && pile.tools.length > 0) {
+    nextPlayer = { ...nextPlayer, tools: [...nextPlayer.tools, ...pile.tools] };
+  }
+  const cap = inventoryCapFromBaskets(basketCount(nextPlayer.tools));
   for (const key of Object.keys(pile.items) as ResourceKind[]) {
     const amt = pile.items[key] ?? 0;
     if (amt <= 0) continue;
-    nextInventory[key] = (nextInventory[key] ?? 0) + amt;
-    pickups.push({ kind: key, amount: amt });
+    const result = addToInventory(nextInventory, key, amt, cap);
+    nextInventory = result.inv;
+    if (result.added > 0) pickups.push({ kind: key, amount: result.added });
   }
-  let nextPlayer = player;
   if (pile.weapons && pile.weapons.length > 0) {
-    nextPlayer = { ...player, weapons: [...player.weapons, ...pile.weapons] };
+    nextPlayer = { ...nextPlayer, weapons: [...nextPlayer.weapons, ...pile.weapons] };
   }
   return {
     player: nextPlayer,
@@ -379,3 +479,15 @@ function isStepBlocked(
   if (!interior) return false;
   return isLocalObstacle(interior, lx, ly);
 }
+
+// Convert the new typed obstacle array into a boolean[] for the legacy bfs()
+// helper which expects a binary occupancy grid.
+function obstacleBoolGrid(interior: BiomeInterior): boolean[] {
+  const out = new Array<boolean>(interior.obstacles.length);
+  for (let i = 0; i < interior.obstacles.length; i++) {
+    out[i] = interior.obstacles[i] != null;
+  }
+  return out;
+}
+// Re-export ObstacleKind so combat.ts can avoid an extra import path.
+export type { ObstacleKind };

--- a/lib/sim/player.ts
+++ b/lib/sim/player.ts
@@ -1,4 +1,6 @@
 import type { WeaponInstance } from "@/lib/sim/weapons";
+import type { ToolInstance } from "@/lib/sim/tools";
+import type { ObstacleKind } from "@/lib/sim/biome-interior";
 
 export type PlayerStats = {
   speed: number;
@@ -10,7 +12,9 @@ export type PlayerStats = {
 
 export type PendingAction =
   | { kind: "collect"; resourceId: string }
-  | { kind: "attack"; npcId: string };
+  | { kind: "attack"; npcId: string }
+  | { kind: "harvest"; rx: number; ry: number; lx: number; ly: number; obstacle: ObstacleKind }
+  | { kind: "workbench"; rx: number; ry: number; lx: number; ly: number };
 
 export type Player = {
   gx: number;
@@ -23,6 +27,7 @@ export type Player = {
   starveAccum: number;
   stats: PlayerStats;
   weapons: WeaponInstance[];
+  tools: ToolInstance[];
   combatCooldown: number;
   route: Array<{ gx: number; gy: number }> | null;
   stepCooldown: number;
@@ -60,6 +65,7 @@ export function createPlayer(spawn: { gx: number; gy: number }): Player {
       reach: BASE_REACH,
     },
     weapons: [],
+    tools: [],
     combatCooldown: 0,
     route: null,
     stepCooldown: 0,

--- a/lib/sim/tools.ts
+++ b/lib/sim/tools.ts
@@ -1,0 +1,56 @@
+export type ToolKind = "axe" | "pickaxe" | "basket" | "torch";
+
+export type ToolMeta = {
+  label: string;
+  durability: number;
+  swatch: string;
+};
+
+export type ToolInstance = {
+  kind: ToolKind;
+  usesLeft: number;
+};
+
+export const TOOLS: Record<ToolKind, ToolMeta> = {
+  axe: { label: "Axe", durability: 30, swatch: "#8a6a4a" },
+  pickaxe: { label: "Pickaxe", durability: 30, swatch: "#5e6675" },
+  basket: { label: "Basket", durability: 999, swatch: "#b6a070" },
+  torch: { label: "Torch", durability: 999, swatch: "#d99348" },
+};
+
+export const TOOL_KINDS: ToolKind[] = ["axe", "pickaxe", "basket", "torch"];
+
+export function makeTool(kind: ToolKind): ToolInstance {
+  return { kind, usesLeft: TOOLS[kind].durability };
+}
+
+export function hasTool(tools: ToolInstance[], kind: ToolKind): boolean {
+  for (const t of tools) {
+    if (t.kind === kind && t.usesLeft > 0) return true;
+  }
+  return false;
+}
+
+export function consumeToolUse(
+  tools: ToolInstance[],
+  kind: ToolKind,
+): ToolInstance[] {
+  let consumed = false;
+  const out: ToolInstance[] = [];
+  for (const t of tools) {
+    if (!consumed && t.kind === kind && t.usesLeft > 0) {
+      consumed = true;
+      const next = t.usesLeft - 1;
+      if (next > 0) out.push({ kind: t.kind, usesLeft: next });
+      continue;
+    }
+    out.push(t);
+  }
+  return out;
+}
+
+export function basketCount(tools: ToolInstance[]): number {
+  let n = 0;
+  for (const t of tools) if (t.kind === "basket") n++;
+  return n;
+}

--- a/lib/sim/weapons.ts
+++ b/lib/sim/weapons.ts
@@ -1,30 +1,27 @@
 import type { Inventory } from "@/lib/sim/inventory";
 import { WEAPONS, type WeaponKind } from "@/content/weapons";
+import type { Recipe } from "@/content/recipes";
+import type { ResourceKind } from "@/content/resources";
 
 export type WeaponInstance = {
   kind: WeaponKind;
   usesLeft: number;
 };
 
-export function affordable(inventory: Inventory, kind: WeaponKind): boolean {
-  const recipe = WEAPONS[kind].recipe;
-  for (const k of Object.keys(recipe) as Array<keyof typeof recipe>) {
-    const need = recipe[k] ?? 0;
+export function affordable(inventory: Inventory, recipe: Recipe): boolean {
+  for (const k of Object.keys(recipe.inputs) as ResourceKind[]) {
+    const need = recipe.inputs[k] ?? 0;
     const have = inventory[k] ?? 0;
     if (have < need) return false;
   }
   return true;
 }
 
-export function spendRecipe(
-  inventory: Inventory,
-  kind: WeaponKind,
-): Inventory | null {
-  if (!affordable(inventory, kind)) return null;
-  const recipe = WEAPONS[kind].recipe;
+export function spendRecipe(inventory: Inventory, recipe: Recipe): Inventory | null {
+  if (!affordable(inventory, recipe)) return null;
   const next: Inventory = { ...inventory };
-  for (const k of Object.keys(recipe) as Array<keyof typeof recipe>) {
-    const need = recipe[k] ?? 0;
+  for (const k of Object.keys(recipe.inputs) as ResourceKind[]) {
+    const need = recipe.inputs[k] ?? 0;
     const have = next[k] ?? 0;
     next[k] = have - need;
   }

--- a/lib/sim/world.ts
+++ b/lib/sim/world.ts
@@ -10,6 +10,8 @@ import {
   generateInterior,
   globalToLocal,
   isLocalObstacle,
+  mixSeed,
+  placeWorkbench,
   regionCenterGlobal,
   regionKey,
   type BiomeInterior,
@@ -23,7 +25,7 @@ import { tickCombat } from "@/lib/sim/combat";
 
 export { biomeAt, isPassable, type Biome } from "@/lib/sim/biome";
 
-export const WORLD_VERSION = 8;
+export const WORLD_VERSION = 9;
 export const MAP_W = 32;
 export const MAP_H = 32;
 export const NPC_COUNT = 200;
@@ -151,22 +153,38 @@ export function claimHome(world: World, rx: number, ry: number): World | null {
 
   const seeded = ensureInteriorsForRegion(world, rx, ry);
   const center = regionCenterGlobal(rx, ry);
-  const interior = seeded.biomeInteriors[regionKey(rx, ry)];
-  if (!interior) return null;
+  const baseInterior = seeded.biomeInteriors[regionKey(rx, ry)];
+  if (!baseInterior) return null;
 
   const spawn = nudgeToOpen(seeded, center.gx, center.gy);
   const player = createPlayer(spawn);
+  const spawnLocal = globalToLocal(spawn.gx, spawn.gy);
+  const wbRng = createRng((mixSeed(seeded.seed, rx, ry) ^ 0x111) >>> 0);
+  const interiorWithBench = placeWorkbench(
+    baseInterior,
+    { lx: spawnLocal.lx, ly: spawnLocal.ly },
+    wbRng,
+  );
+  const biomeInteriors = {
+    ...seeded.biomeInteriors,
+    [regionKey(rx, ry)]: interiorWithBench,
+  };
   const discoveredRegions = { ...seeded.discoveredRegions, [regionKey(rx, ry)]: true as const };
   return {
     ...seeded,
+    biomeInteriors,
     player,
     home: { rx, ry },
     discoveredRegions,
   };
 }
 
-export function tickWorld(world: World): { world: World; event: WorldEvent | null } {
-  if (world.gameOver) return { world, event: null };
+export function tickWorld(world: World): {
+  world: World;
+  event: WorldEvent | null;
+  workbenchOpened: boolean;
+} {
+  if (world.gameOver) return { world, event: null, workbenchOpened: false };
 
   const rng = createRng(world.rngState);
   const playerRegion = world.player ? globalToLocal(world.player.gx, world.player.gy) : null;
@@ -197,6 +215,7 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
   let gameOver: boolean = world.gameOver;
   let gameOverReason: GameOverReason | null = world.gameOverReason;
   let discoveredRegions = world.discoveredRegions;
+  let workbenchOpened = false;
 
   if (player) {
     const stepped = tickPlayer({
@@ -214,6 +233,7 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
     const npcsBefore = npcs;
     npcs = stepped.npcs;
     playerReputation = stepped.playerReputation;
+    if (stepped.workbenchOpened) workbenchOpened = true;
     // Stamp the player's faction-attack ledger when an NPC took damage from
     // the player this tick (detected by health drop on a still-living NPC).
     for (const before of npcsBefore) {
@@ -271,6 +291,7 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
       player = {
         ...player,
         weapons: [],
+        tools: [],
         route: null,
         pendingAction: null,
         stepCooldown: 0,
@@ -320,6 +341,7 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
       player = {
         ...player,
         weapons: [],
+        tools: [],
         route: null,
         pendingAction: null,
         stepCooldown: 0,
@@ -394,7 +416,7 @@ export function tickWorld(world: World): { world: World; event: WorldEvent | nul
       next.rngState = rng.state();
     }
   }
-  return { world: next, event };
+  return { world: next, event, workbenchOpened };
 }
 
 function updatePresence(
@@ -486,13 +508,15 @@ function dropDeathLoot(
     if (v > 0) items[key] = v;
   }
   const weapons = player.weapons.length > 0 ? [...player.weapons] : undefined;
-  if (Object.keys(items).length === 0 && !weapons) return { interiors };
+  const tools = player.tools.length > 0 ? [...player.tools] : undefined;
+  if (Object.keys(items).length === 0 && !weapons && !tools) return { interiors };
   const pile = {
     id: `grave-${ticks}-${rx}-${ry}-${lx}-${ly}`,
     lx,
     ly,
     items,
     weapons,
+    tools,
     fromDeath: true,
   };
   const next = { ...interior, loot: [...interior.loot, pile] };

--- a/lib/state/game-store.ts
+++ b/lib/state/game-store.ts
@@ -16,15 +16,20 @@ import { bus } from "@/lib/render/bus";
 import type { WorldEvent } from "@/lib/sim/events";
 import { gainPlayerRep } from "@/lib/sim/faction";
 import {
+  findWorkbenchTile,
   globalToLocal,
   isLocalObstacle,
+  localToGlobal,
+  obstacleKindAt,
   regionCenterGlobal,
   regionKey,
   resourceAtLocal,
   INTERIOR_W,
   INTERIOR_H,
+  type ObstacleKind,
 } from "@/lib/sim/biome-interior";
 import { bfsPredicate } from "@/lib/sim/path";
+import { chebyshev } from "@/lib/sim/combat";
 import type { PendingAction, Player } from "@/lib/sim/player";
 import { createPlayer } from "@/lib/sim/player";
 import { setPendingAttack } from "@/lib/sim/player-tick";
@@ -33,7 +38,8 @@ import {
   makeWeapon,
   spendRecipe,
 } from "@/lib/sim/weapons";
-import type { WeaponKind } from "@/content/weapons";
+import { makeTool } from "@/lib/sim/tools";
+import { RECIPES_BY_ID } from "@/content/recipes";
 import { RESOURCES, type ResourceKind } from "@/content/resources";
 import { EAT_ENERGY_PER_FOOD, EAT_HEALTH_PER_FOOD } from "@/lib/sim/player";
 
@@ -44,6 +50,15 @@ export type SelectedRegion = { rx: number; ry: number };
 export type View = "world" | "biome";
 
 export type NpcContextMenu = { id: string; x: number; y: number };
+export type ObstacleContextMenuState = {
+  rx: number;
+  ry: number;
+  lx: number;
+  ly: number;
+  kind: ObstacleKind;
+  x: number;
+  y: number;
+};
 
 type GameStore = {
   world: World | null;
@@ -55,11 +70,13 @@ type GameStore = {
   view: View;
   homePending: boolean;
   inventoryOpen: boolean;
+  workbenchOpen: boolean;
   tutorialOpen: boolean;
   debugMode: boolean;
   debugMinimized: boolean;
   mapShowFactions: boolean;
   npcContextMenu: NpcContextMenu | null;
+  obstacleContextMenu: ObstacleContextMenuState | null;
 
   startNew: () => void;
   loadFromDisk: (slot: string) => Promise<void>;
@@ -75,16 +92,25 @@ type GameStore = {
   setView: (v: View) => void;
   walkPlayerTo: (gx: number, gy: number) => void;
   travelToRegion: (rx: number, ry: number) => void;
+  interactWithObstacle: (
+    rx: number,
+    ry: number,
+    lx: number,
+    ly: number,
+    action: "harvest" | "workbench",
+  ) => void;
   resetAfterDeath: () => void;
 
   acceptEncounter: () => void;
   dismissEncounter: () => void;
 
-  craft: (kind: WeaponKind) => boolean;
+  craftRecipe: (recipeId: string) => boolean;
   attackNpc: (id: string) => void;
 
   openInventory: () => void;
   closeInventory: () => void;
+  openWorkbench: () => void;
+  closeWorkbench: () => void;
   openTutorial: () => void;
   closeTutorial: () => void;
   toggleDebug: () => void;
@@ -92,6 +118,16 @@ type GameStore = {
   toggleMapFactions: () => void;
   openNpcContextMenu: (id: string, x: number, y: number) => void;
   closeNpcContextMenu: () => void;
+  openObstacleContextMenu: (
+    rx: number,
+    ry: number,
+    lx: number,
+    ly: number,
+    kind: ObstacleKind,
+    x: number,
+    y: number,
+  ) => void;
+  closeObstacleContextMenu: () => void;
   eatFood: (kind: import("@/content/resources").ResourceKind) => void;
   teleportToRegion: (rx: number, ry: number) => void;
   inspectBiome: (rx: number, ry: number) => void;
@@ -107,11 +143,13 @@ export const useGameStore = create<GameStore>((set, get) => ({
   view: "world",
   homePending: false,
   inventoryOpen: false,
+  workbenchOpen: false,
   tutorialOpen: false,
   debugMode: false,
   debugMinimized: false,
   mapShowFactions: true,
   npcContextMenu: null,
+  obstacleContextMenu: null,
 
   startNew: () => {
     set({
@@ -123,7 +161,10 @@ export const useGameStore = create<GameStore>((set, get) => ({
       view: "world",
       homePending: true,
       inventoryOpen: false,
+      workbenchOpen: false,
       tutorialOpen: true,
+      npcContextMenu: null,
+      obstacleContextMenu: null,
     });
   },
 
@@ -149,12 +190,20 @@ export const useGameStore = create<GameStore>((set, get) => ({
   tick: () => {
     const current = get().world;
     if (!current) return;
-    const { world, event } = tickWorld(current);
+    const { world, event, workbenchOpened } = tickWorld(current);
     const patch: Partial<GameStore> = {
       world,
       lastEvent: event ?? get().lastEvent,
     };
     if (world.gameOver && !current.gameOver) patch.paused = true;
+    if (workbenchOpened) {
+      patch.workbenchOpen = true;
+      patch.selectedNpcId = null;
+      patch.selectedRegion = null;
+      patch.inventoryOpen = false;
+      patch.npcContextMenu = null;
+      patch.obstacleContextMenu = null;
+    }
     set(patch);
     if (world.ticks % AUTOSAVE_EVERY_TICKS === 0) {
       void saveWorld("default", world);
@@ -165,11 +214,21 @@ export const useGameStore = create<GameStore>((set, get) => ({
   setSpeed: (s) => set({ speed: s }),
 
   selectNpc: (id) => {
-    set({ selectedNpcId: id, selectedRegion: id ? null : get().selectedRegion });
+    set({
+      selectedNpcId: id,
+      selectedRegion: id ? null : get().selectedRegion,
+      obstacleContextMenu: id ? null : get().obstacleContextMenu,
+      workbenchOpen: id ? false : get().workbenchOpen,
+    });
     if (!id) bus.emit("npc:deselected");
   },
   selectRegion: (region) => {
-    set({ selectedRegion: region, selectedNpcId: region ? null : get().selectedNpcId });
+    set({
+      selectedRegion: region,
+      selectedNpcId: region ? null : get().selectedNpcId,
+      obstacleContextMenu: region ? null : get().obstacleContextMenu,
+      workbenchOpen: region ? false : get().workbenchOpen,
+    });
     if (region) bus.emit("npc:deselected");
   },
 
@@ -184,13 +243,20 @@ export const useGameStore = create<GameStore>((set, get) => ({
       view: "biome",
       selectedNpcId: null,
       selectedRegion: null,
+      obstacleContextMenu: null,
     });
     void saveWorld("default", next);
   },
 
   setView: (v) => {
     if (v === get().view) return;
-    set({ view: v, selectedNpcId: null, selectedRegion: null });
+    set({
+      view: v,
+      selectedNpcId: null,
+      selectedRegion: null,
+      obstacleContextMenu: null,
+      workbenchOpen: false,
+    });
     bus.emit("npc:deselected");
   },
 
@@ -199,9 +265,6 @@ export const useGameStore = create<GameStore>((set, get) => ({
     if (!current || !current.player) return;
     if (current.gameOver) return;
 
-    // Make sure source + target regions (and a small buffer around the
-    // target) are generated before BFS reads obstacles. Without this,
-    // unvisited tiles look passable, which would break "feels like a wall".
     const startingPlayer: Player = current.player;
     let world = current;
     const src = globalToLocal(startingPlayer.gx, startingPlayer.gy);
@@ -261,19 +324,90 @@ export const useGameStore = create<GameStore>((set, get) => ({
       view: "biome",
       selectedNpcId: null,
       selectedRegion: null,
+      obstacleContextMenu: null,
+      workbenchOpen: false,
     });
     bus.emit("npc:deselected");
     const center = regionCenterGlobal(rx, ry);
     get().walkPlayerTo(center.gx, center.gy);
   },
 
+  interactWithObstacle: (rx, ry, lx, ly, action) => {
+    const current = get().world;
+    if (!current?.player || current.gameOver) return;
+    let world = ensureInteriorsForRegion(current, rx, ry);
+    const interior = world.biomeInteriors[regionKey(rx, ry)];
+    if (!interior) return;
+    const obstacle = obstacleKindAt(interior, lx, ly);
+    if (!obstacle) {
+      set({ obstacleContextMenu: null });
+      return;
+    }
+
+    const startingPlayer = world.player!;
+    const isObstacle = (tgx: number, tgy: number): boolean => {
+      const loc = globalToLocal(tgx, tgy);
+      if (loc.rx < 0 || loc.ry < 0 || loc.rx >= MAP_W || loc.ry >= MAP_H) return true;
+      if (loc.lx < 0 || loc.ly < 0 || loc.lx >= INTERIOR_W || loc.ly >= INTERIOR_H) return true;
+      const i2 = world.biomeInteriors[regionKey(loc.rx, loc.ry)];
+      if (!i2) {
+        const w2 = ensureInteriorsForRegion(world, loc.rx, loc.ry);
+        if (w2 !== world) world = w2;
+        const fresh = world.biomeInteriors[regionKey(loc.rx, loc.ry)];
+        if (!fresh) return true;
+        return isLocalObstacle(fresh, loc.lx, loc.ly);
+      }
+      return isLocalObstacle(i2, loc.lx, loc.ly);
+    };
+
+    let bestPath: Array<{ gx: number; gy: number }> | null = null;
+    for (let dy = -1; dy <= 1; dy++) {
+      for (let dx = -1; dx <= 1; dx++) {
+        if (dx === 0 && dy === 0) continue;
+        const tlx = lx + dx;
+        const tly = ly + dy;
+        if (tlx < 0 || tly < 0 || tlx >= INTERIOR_W || tly >= INTERIOR_H) continue;
+        if (isLocalObstacle(interior, tlx, tly)) continue;
+        const tg = localToGlobal(rx, ry, tlx, tly);
+        const path = bfsPredicate(
+          isObstacle,
+          startingPlayer.gx,
+          startingPlayer.gy,
+          tg.gx,
+          tg.gy,
+          WALK_MAX_RADIUS,
+        );
+        if (!path) continue;
+        if (!bestPath || path.length < bestPath.length) bestPath = path;
+      }
+    }
+
+    if (!bestPath) {
+      set({ obstacleContextMenu: null });
+      return;
+    }
+
+    const pendingAction: PendingAction =
+      action === "harvest"
+        ? { kind: "harvest", rx, ry, lx, ly, obstacle }
+        : { kind: "workbench", rx, ry, lx, ly };
+
+    const player: Player = {
+      ...startingPlayer,
+      route: bestPath.length === 0 ? null : bestPath,
+      stepCooldown: bestPath.length === 0 ? 0 : Math.max(1, startingPlayer.stats.speed),
+      pendingAction,
+    };
+    set({
+      world: { ...world, player },
+      obstacleContextMenu: null,
+      npcContextMenu: null,
+    });
+  },
+
   resetAfterDeath: () => {
     const current = get().world;
     if (!current) return;
-    // Respawn into the same world: keep NPCs, factions, regions, faction
-    // relations, and any death loot we just dropped. Only the player and
-    // the run-specific UI flags reset. If the player never settled a home
-    // we can't respawn — fall back to a fresh world (treat it like a new game).
     if (!current.home) {
       set({
         world: createWorld(),
@@ -284,8 +418,10 @@ export const useGameStore = create<GameStore>((set, get) => ({
         view: "world",
         homePending: true,
         inventoryOpen: false,
+        workbenchOpen: false,
         tutorialOpen: false,
         npcContextMenu: null,
+        obstacleContextMenu: null,
       });
       return;
     }
@@ -311,8 +447,10 @@ export const useGameStore = create<GameStore>((set, get) => ({
       view: "biome",
       homePending: false,
       inventoryOpen: false,
+      workbenchOpen: false,
       tutorialOpen: false,
       npcContextMenu: null,
+      obstacleContextMenu: null,
     });
   },
 
@@ -339,18 +477,37 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   dismissEncounter: () => set({ lastEvent: null }),
 
-  craft: (kind) => {
+  craftRecipe: (recipeId) => {
     const current = get().world;
-    if (!current?.player) return false;
-    if (!affordable(current.inventory, kind)) return false;
-    const nextInventory = spendRecipe(current.inventory, kind);
+    if (!current?.player || current.gameOver) return false;
+    const recipe = RECIPES_BY_ID[recipeId];
+    if (!recipe) return false;
+    if (recipe.station === "workbench") {
+      const here = globalToLocal(current.player.gx, current.player.gy);
+      const interior = current.biomeInteriors[regionKey(here.rx, here.ry)];
+      if (!interior) return false;
+      const wb = findWorkbenchTile(interior);
+      if (!wb || chebyshev(here.lx, here.ly, wb.lx, wb.ly) > 1) return false;
+    }
+    if (!affordable(current.inventory, recipe)) return false;
+    const nextInventory = spendRecipe(current.inventory, recipe);
     if (!nextInventory) return false;
-    const weapon = makeWeapon(kind);
-    const player: Player = {
-      ...current.player,
-      weapons: [...current.player.weapons, weapon],
-    };
-    set({ world: { ...current, inventory: nextInventory, player } });
+    let player: Player = current.player;
+    if (recipe.result.kind === "weapon") {
+      const w = makeWeapon(recipe.result.id);
+      player = { ...player, weapons: [...player.weapons, w] };
+    } else {
+      const t = makeTool(recipe.result.id);
+      player = { ...player, tools: [...player.tools, t] };
+    }
+    set({
+      world: {
+        ...current,
+        inventory: nextInventory,
+        player,
+        ticks: current.ticks + recipe.time,
+      },
+    });
     return true;
   },
 
@@ -364,10 +521,23 @@ export const useGameStore = create<GameStore>((set, get) => ({
   openInventory: () =>
     set({
       inventoryOpen: true,
+      workbenchOpen: false,
       selectedNpcId: null,
       selectedRegion: null,
+      obstacleContextMenu: null,
+      npcContextMenu: null,
     }),
   closeInventory: () => set({ inventoryOpen: false }),
+  openWorkbench: () =>
+    set({
+      workbenchOpen: true,
+      inventoryOpen: false,
+      selectedNpcId: null,
+      selectedRegion: null,
+      obstacleContextMenu: null,
+      npcContextMenu: null,
+    }),
+  closeWorkbench: () => set({ workbenchOpen: false }),
   openTutorial: () => set({ tutorialOpen: true }),
   closeTutorial: () => set({ tutorialOpen: false }),
   toggleDebug: () => set({ debugMode: !get().debugMode }),
@@ -377,10 +547,23 @@ export const useGameStore = create<GameStore>((set, get) => ({
   openNpcContextMenu: (id, x, y) =>
     set({
       npcContextMenu: { id, x, y },
+      obstacleContextMenu: null,
       selectedNpcId: null,
       selectedRegion: null,
+      workbenchOpen: false,
     }),
   closeNpcContextMenu: () => set({ npcContextMenu: null }),
+
+  openObstacleContextMenu: (rx, ry, lx, ly, kind, x, y) =>
+    set({
+      obstacleContextMenu: { rx, ry, lx, ly, kind, x, y },
+      npcContextMenu: null,
+      selectedNpcId: null,
+      selectedRegion: null,
+      inventoryOpen: false,
+      workbenchOpen: false,
+    }),
+  closeObstacleContextMenu: () => set({ obstacleContextMenu: null }),
 
   eatFood: (kind: ResourceKind) => {
     const current = get().world;
@@ -418,6 +601,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
       view: "biome",
       selectedNpcId: null,
       selectedRegion: null,
+      obstacleContextMenu: null,
+      workbenchOpen: false,
     });
     bus.emit("npc:deselected");
   },


### PR DESCRIPTION
Closes #10.

## Summary

- Introduces the **`ObstacleContextMenu`** primitive — RuneScape-style tap-to-act on impassables. Tapping a tree, rock, cactus, bush, or workbench opens a menu that holds the entire action space (`Examine`, `Chop` / `Mine` / `Craft`), with tool-gated entries greyed out. Tools no longer change the BFS predicate; harvesting goes through the menu, route, and a typed `pendingAction` that fires on arrival.
- Adds a **workbench** at the home claim (deterministically placed in `claimHome` from the home seed) and a `WorkbenchPanel` opened via the menu's Craft action.
- Unifies recipes in **`content/recipes.ts`**: hand recipes (stick / club / sling) plus workbench recipes for axe, pickaxe, basket, torch, sword, bow.
- Adds **tools** (`lib/sim/tools.ts`) with per-instance durability; baskets raise the inventory cap (20 → 40 → 60 → 80 via `inventoryCapFromBaskets`).
- Adds **sword** (+3 atk melee, durability 30) and **bow** (+2 atk, reach 5, ranged, durability 25) to `WEAPONS`. `affordable` / `spendRecipe` now take a `Recipe` instead of reading `WEAPONS[kind].recipe`.
- Bumps **`WORLD_VERSION` 8 → 9**: `BiomeInterior.obstacles` is now `(ObstacleKind | null)[]`; `Player` gains `tools: ToolInstance[]`; `LootPile` carries tools so death loot persists them.
- HUD inventory strip splits into a stash row (with `total/cap`) and a tools row with SVG durability rings. `RegionPanel` adds a "Resources here" aggregation. `BiomeScene.drawObstacle` switches on `ObstacleKind` and gains a workbench sprite.

Related issue updates also pushed: #11, #14, #9, #8 now reference the new primitive so later phases plug into it.

## Test plan

- [x] `npm run typecheck && npm run lint --max-warnings 0 && npm run build` all pass (verified locally)
- [x] Start a new game; claim a home — workbench obstacle visible near spawn
- [x] Tap workbench → context menu shows Examine + Craft → tap Craft → walks adjacent → `WorkbenchPanel` opens
- [x] Forage wood + stone, craft Axe at the workbench → ticks bump by 4, axe appears in HUD tools row with full durability ring
- [x] Tap a tree → menu shows Examine + Chop. With axe: Chop enabled → walks adjacent → tree clears, +1 wood toast, axe ring shrinks
- [x] Tap a tree without an axe → Chop is greyed with "needs axe" subtitle
- [x] Tap a rock with pickaxe → +1 stone (occasional +1 ore in stone biome)
- [x] Tap cactus / bush → only Examine shown
- [x] Craft Basket → HUD inventory cap reads `n/40`; second basket → `n/60`
- [x] Craft Sword + Bow → tap NPC → context menu Attack → sword auto-picks at melee, bow at distance 2–5
- [x] Die. Respawn at home; walk to death tile → loot pile contains weapons **and tools**
- [x] Reload after claiming a home → workbench reappears at the same tile (deterministic placement)
- [x] Existing version-8 saves are discarded and a fresh world starts on load
- [x] Vercel preview verified on phone (≥ 44px hit targets on the context menu and workbench panel)

https://claude.ai/code/session_01XeUfkeDsDekfAifgYPqGHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeUfkeDsDekfAifgYPqGHy)_