### PR TITLE
Make the workbench craftable; remove auto-placement at home

### DIFF
--- a/components/ObstacleContextMenu.tsx
+++ b/components/ObstacleContextMenu.tsx
@@ -137,6 +137,13 @@ export default function ObstacleContextMenu() {
       icon: "hammer",
       onClick: () => interact(rx, ry, lx, ly, "workbench"),
     });
+    actions.push({
+      id: "deconstruct",
+      label: "Deconstruct",
+      description: "recover materials",
+      icon: "hammer",
+      onClick: () => interact(rx, ry, lx, ly, "deconstruct"),
+    });
   }
 
   const onPointerDown = (e: React.PointerEvent) => {

--- a/components/panels/InventoryPanel.tsx
+++ b/components/panels/InventoryPanel.tsx
@@ -5,7 +5,7 @@ import { useGameStore } from "@/lib/state/game-store";
 import { RESOURCES, type ResourceKind } from "@/content/resources";
 import { WEAPONS } from "@/content/weapons";
 import { TOOLS } from "@/lib/sim/tools";
-import { RECIPES } from "@/content/recipes";
+import { RECIPES, type Recipe } from "@/content/recipes";
 import { affordable } from "@/lib/sim/weapons";
 import { inventoryCapFromBaskets, inventoryTotal } from "@/lib/sim/inventory";
 import { basketCount } from "@/lib/sim/tools";
@@ -180,13 +180,11 @@ export default function InventoryPanel() {
           </h3>
           <ul className="mt-3 flex flex-col gap-2">
             {handRecipes.map((recipe) => {
-              const meta = WEAPONS[
-                recipe.result.kind === "weapon" ? recipe.result.id : "stick"
-              ];
               const can =
                 Boolean(player) &&
                 !world.gameOver &&
                 affordable(inventory, recipe);
+              const stats = describeHandResult(recipe);
               return (
                 <li key={recipe.id}>
                   <button
@@ -204,10 +202,10 @@ export default function InventoryPanel() {
                         {recipe.name}
                       </span>
                       <span className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
-                        <span>+{meta.attack} atk</span>
-                        <span>reach {meta.reach}</span>
-                        {meta.ranged && <span>ranged</span>}
-                        <span>· uses {meta.durability}</span>
+                        {stats.map((s) => (
+                          <span key={s}>{s}</span>
+                        ))}
+                        {recipe.time > 0 && <span>· {recipe.time} ticks</span>}
                       </span>
                       <span className="mt-1 flex flex-wrap gap-1.5">
                         {(Object.entries(recipe.inputs) as Array<[
@@ -235,13 +233,27 @@ export default function InventoryPanel() {
             More at the workbench
           </h3>
           <p className="mt-2 text-sm text-[var(--color-fg-muted)]">
-            Tap the workbench at home to craft tools (axe, pickaxe, basket,
-            torch) and advanced weapons (sword, bow).
+            Place a workbench, then tap it to craft tools (axe, pickaxe,
+            basket, torch) and advanced weapons (sword, bow).
           </p>
         </section>
       </div>
     </aside>
   );
+}
+
+function describeHandResult(recipe: Recipe): string[] {
+  if (recipe.result.kind === "weapon") {
+    const meta = WEAPONS[recipe.result.id];
+    const out = [`+${meta.attack} atk`, `reach ${meta.reach}`];
+    if (meta.ranged) out.push("ranged");
+    out.push(`uses ${meta.durability}`);
+    return out;
+  }
+  if (recipe.result.kind === "structure") {
+    return ["places nearby", "tap to craft tools"];
+  }
+  return [];
 }
 
 function RecipePip({

--- a/components/panels/WorkbenchPanel.tsx
+++ b/components/panels/WorkbenchPanel.tsx
@@ -144,14 +144,13 @@ function describeResult(recipe: Recipe): string[] {
     out.push(`uses ${meta.durability}`);
     return out;
   }
-  const meta = TOOLS[recipe.result.id];
-  if (recipe.result.id === "basket") {
-    return ["+20 inventory cap"];
+  if (recipe.result.kind === "tool") {
+    const meta = TOOLS[recipe.result.id];
+    if (recipe.result.id === "basket") return ["+20 inventory cap"];
+    if (recipe.result.id === "torch") return ["+3 sight (Phase 6)"];
+    return [`uses ${meta.durability}`];
   }
-  if (recipe.result.id === "torch") {
-    return ["+3 sight (Phase 6)"];
-  }
-  return [`uses ${meta.durability}`];
+  return ["places nearby"];
 }
 
 function RecipePip({

--- a/content/recipes.ts
+++ b/content/recipes.ts
@@ -105,3 +105,10 @@ export const RECIPES: Recipe[] = [
 
 export const RECIPES_BY_ID: Record<string, Recipe> = {};
 for (const r of RECIPES) RECIPES_BY_ID[r.id] = r;
+
+export function recipeForStructure(kind: StructureKind): Recipe | null {
+  for (const r of RECIPES) {
+    if (r.result.kind === "structure" && r.result.id === kind) return r;
+  }
+  return null;
+}

--- a/content/recipes.ts
+++ b/content/recipes.ts
@@ -4,9 +4,12 @@ import type { ToolKind } from "@/lib/sim/tools";
 
 export type RecipeStation = "hand" | "workbench";
 
+export type StructureKind = "workbench";
+
 export type RecipeResult =
   | { kind: "weapon"; id: WeaponKind }
-  | { kind: "tool"; id: ToolKind };
+  | { kind: "tool"; id: ToolKind }
+  | { kind: "structure"; id: StructureKind };
 
 export type Recipe = {
   id: string;
@@ -40,6 +43,14 @@ export const RECIPES: Recipe[] = [
     result: { kind: "weapon", id: "sling" },
     inputs: { reed: 2, stone: 1 },
     time: 0,
+    station: "hand",
+  },
+  {
+    id: "workbench",
+    name: "Workbench",
+    result: { kind: "structure", id: "workbench" },
+    inputs: { wood: 4, stone: 2 },
+    time: 5,
     station: "hand",
   },
   {

--- a/lib/sim/biome-interior.ts
+++ b/lib/sim/biome-interior.ts
@@ -178,6 +178,46 @@ export function findWorkbenchTile(
   return null;
 }
 
+// Spiral-search for the first tile within `radius` of (lx, ly) that is
+// passable and not occupied by a resource. Deterministic — used by
+// player-initiated structure placement so the chosen slot is stable.
+export function findAdjacentPassable(
+  interior: BiomeInterior,
+  lx: number,
+  ly: number,
+  radius: number,
+): { lx: number; ly: number } | null {
+  for (let r = 1; r <= radius; r++) {
+    for (let dy = -r; dy <= r; dy++) {
+      for (let dx = -r; dx <= r; dx++) {
+        if (Math.abs(dx) !== r && Math.abs(dy) !== r) continue;
+        const tlx = lx + dx;
+        const tly = ly + dy;
+        if (tlx < 0 || tly < 0 || tlx >= INTERIOR_W || tly >= INTERIOR_H) continue;
+        const idx = tly * INTERIOR_W + tlx;
+        if (interior.obstacles[idx] != null) continue;
+        if (interior.resources.some((res) => res.lx === tlx && res.ly === tly)) continue;
+        return { lx: tlx, ly: tly };
+      }
+    }
+  }
+  return null;
+}
+
+export function placeObstacle(
+  interior: BiomeInterior,
+  lx: number,
+  ly: number,
+  kind: ObstacleKind,
+): BiomeInterior {
+  if (lx < 0 || ly < 0 || lx >= INTERIOR_W || ly >= INTERIOR_H) return interior;
+  const idx = ly * INTERIOR_W + lx;
+  if (interior.obstacles[idx] != null) return interior;
+  const next = interior.obstacles.slice();
+  next[idx] = kind;
+  return { ...interior, obstacles: next };
+}
+
 export function resourceAtLocal(
   interior: BiomeInterior,
   lx: number,

--- a/lib/sim/player-tick.ts
+++ b/lib/sim/player-tick.ts
@@ -7,6 +7,7 @@ import {
 import {
   INTERIOR_W,
   INTERIOR_H,
+  addLoot,
   globalToLocal,
   isLocalObstacle,
   localToGlobal,
@@ -18,8 +19,10 @@ import {
   obstacleKindAt,
   clearObstacle,
   type BiomeInterior,
+  type LootPile,
   type ObstacleKind,
 } from "@/lib/sim/biome-interior";
+import { recipeForStructure } from "@/content/recipes";
 import {
   addToInventory,
   inventoryCapFromBaskets,
@@ -183,6 +186,12 @@ export function tickPlayer(input: PlayerTickInput): PlayerTickOutput {
         workbenchOpened = true;
       }
       player = { ...player, pendingAction: null };
+    } else if (action.kind === "deconstruct") {
+      const result = tryDeconstruct(player, interiors, inventory, action, ticks);
+      player = result.player;
+      interiors = result.interiors;
+      inventory = result.inventory;
+      for (const p of result.pickups) pickups.push(p);
     } else if (action.kind === "attack") {
       const targetIdx = npcs.findIndex((n) => n.id === action.npcId);
       if (targetIdx >= 0) {
@@ -425,6 +434,71 @@ function tryHarvest(
     interiors: updatedInteriors,
     inventory: added.inv,
     pickup: { kind: drop, amount: added.added },
+  };
+}
+
+function tryDeconstruct(
+  player: Player,
+  interiors: Record<string, BiomeInterior>,
+  inventory: Inventory,
+  action: Extract<PendingAction, { kind: "deconstruct" }>,
+  ticks: number,
+): {
+  player: Player;
+  interiors: Record<string, BiomeInterior>;
+  inventory: Inventory;
+  pickups: PickupNotice[];
+} {
+  const nextPlayer: Player = { ...player, pendingAction: null };
+  const here = globalToLocal(player.gx, player.gy);
+  if (here.rx !== action.rx || here.ry !== action.ry) {
+    return { player: nextPlayer, interiors, inventory, pickups: [] };
+  }
+  if (chebyshev(here.lx, here.ly, action.lx, action.ly) > 1) {
+    return { player: nextPlayer, interiors, inventory, pickups: [] };
+  }
+  const k = regionKey(action.rx, action.ry);
+  const interior = interiors[k];
+  if (!interior) return { player: nextPlayer, interiors, inventory, pickups: [] };
+  const stillThere = obstacleKindAt(interior, action.lx, action.ly);
+  if (stillThere !== action.obstacle) {
+    return { player: nextPlayer, interiors, inventory, pickups: [] };
+  }
+  if (action.obstacle !== "workbench") {
+    return { player: nextPlayer, interiors, inventory, pickups: [] };
+  }
+  const recipe = recipeForStructure(action.obstacle);
+  if (!recipe) return { player: nextPlayer, interiors, inventory, pickups: [] };
+
+  const cap = inventoryCapFromBaskets(basketCount(nextPlayer.tools));
+  let nextInventory: Inventory = inventory;
+  const pickups: PickupNotice[] = [];
+  const overflow: Inventory = {};
+  for (const key of Object.keys(recipe.inputs) as ResourceKind[]) {
+    const need = recipe.inputs[key] ?? 0;
+    if (need <= 0) continue;
+    const result = addToInventory(nextInventory, key, need, cap);
+    nextInventory = result.inv;
+    if (result.added > 0) pickups.push({ kind: key, amount: result.added });
+    const leftover = need - result.added;
+    if (leftover > 0) overflow[key] = (overflow[key] ?? 0) + leftover;
+  }
+
+  let updatedInterior = clearObstacle(interior, action.lx, action.ly);
+  if (Object.keys(overflow).length > 0) {
+    const pile: LootPile = {
+      id: `dec-${ticks}-${action.rx}-${action.ry}-${action.lx}-${action.ly}`,
+      lx: action.lx,
+      ly: action.ly,
+      items: overflow,
+    };
+    updatedInterior = addLoot(updatedInterior, pile);
+  }
+  return {
+    player: nextPlayer,
+    interiors: { ...interiors, [k]: updatedInterior },
+    inventory: nextInventory,
+    pickups,
   };
 }
 

--- a/lib/sim/player.ts
+++ b/lib/sim/player.ts
@@ -14,7 +14,15 @@ export type PendingAction =
   | { kind: "collect"; resourceId: string }
   | { kind: "attack"; npcId: string }
   | { kind: "harvest"; rx: number; ry: number; lx: number; ly: number; obstacle: ObstacleKind }
-  | { kind: "workbench"; rx: number; ry: number; lx: number; ly: number };
+  | { kind: "workbench"; rx: number; ry: number; lx: number; ly: number }
+  | {
+      kind: "deconstruct";
+      rx: number;
+      ry: number;
+      lx: number;
+      ly: number;
+      obstacle: ObstacleKind;
+    };
 
 export type Player = {
   gx: number;

--- a/lib/sim/world.ts
+++ b/lib/sim/world.ts
@@ -10,8 +10,6 @@ import {
   generateInterior,
   globalToLocal,
   isLocalObstacle,
-  mixSeed,
-  placeWorkbench,
   regionCenterGlobal,
   regionKey,
   type BiomeInterior,
@@ -153,26 +151,14 @@ export function claimHome(world: World, rx: number, ry: number): World | null {
 
   const seeded = ensureInteriorsForRegion(world, rx, ry);
   const center = regionCenterGlobal(rx, ry);
-  const baseInterior = seeded.biomeInteriors[regionKey(rx, ry)];
-  if (!baseInterior) return null;
+  const interior = seeded.biomeInteriors[regionKey(rx, ry)];
+  if (!interior) return null;
 
   const spawn = nudgeToOpen(seeded, center.gx, center.gy);
   const player = createPlayer(spawn);
-  const spawnLocal = globalToLocal(spawn.gx, spawn.gy);
-  const wbRng = createRng((mixSeed(seeded.seed, rx, ry) ^ 0x111) >>> 0);
-  const interiorWithBench = placeWorkbench(
-    baseInterior,
-    { lx: spawnLocal.lx, ly: spawnLocal.ly },
-    wbRng,
-  );
-  const biomeInteriors = {
-    ...seeded.biomeInteriors,
-    [regionKey(rx, ry)]: interiorWithBench,
-  };
   const discoveredRegions = { ...seeded.discoveredRegions, [regionKey(rx, ry)]: true as const };
   return {
     ...seeded,
-    biomeInteriors,
     player,
     home: { rx, ry },
     discoveredRegions,

--- a/lib/state/game-store.ts
+++ b/lib/state/game-store.ts
@@ -99,7 +99,7 @@ type GameStore = {
     ry: number,
     lx: number,
     ly: number,
-    action: "harvest" | "workbench",
+    action: "harvest" | "workbench" | "deconstruct",
   ) => void;
   resetAfterDeath: () => void;
 
@@ -389,10 +389,14 @@ export const useGameStore = create<GameStore>((set, get) => ({
       return;
     }
 
-    const pendingAction: PendingAction =
-      action === "harvest"
-        ? { kind: "harvest", rx, ry, lx, ly, obstacle }
-        : { kind: "workbench", rx, ry, lx, ly };
+    let pendingAction: PendingAction;
+    if (action === "harvest") {
+      pendingAction = { kind: "harvest", rx, ry, lx, ly, obstacle };
+    } else if (action === "deconstruct") {
+      pendingAction = { kind: "deconstruct", rx, ry, lx, ly, obstacle };
+    } else {
+      pendingAction = { kind: "workbench", rx, ry, lx, ly };
+    }
 
     const player: Player = {
       ...startingPlayer,

--- a/lib/state/game-store.ts
+++ b/lib/state/game-store.ts
@@ -16,11 +16,13 @@ import { bus } from "@/lib/render/bus";
 import type { WorldEvent } from "@/lib/sim/events";
 import { gainPlayerRep } from "@/lib/sim/faction";
 import {
+  findAdjacentPassable,
   findWorkbenchTile,
   globalToLocal,
   isLocalObstacle,
   localToGlobal,
   obstacleKindAt,
+  placeObstacle,
   regionCenterGlobal,
   regionKey,
   resourceAtLocal,
@@ -482,12 +484,24 @@ export const useGameStore = create<GameStore>((set, get) => ({
     if (!current?.player || current.gameOver) return false;
     const recipe = RECIPES_BY_ID[recipeId];
     if (!recipe) return false;
+    const here = globalToLocal(current.player.gx, current.player.gy);
+    const interior = current.biomeInteriors[regionKey(here.rx, here.ry)];
     if (recipe.station === "workbench") {
-      const here = globalToLocal(current.player.gx, current.player.gy);
-      const interior = current.biomeInteriors[regionKey(here.rx, here.ry)];
       if (!interior) return false;
       const wb = findWorkbenchTile(interior);
       if (!wb || chebyshev(here.lx, here.ly, wb.lx, wb.ly) > 1) return false;
+    }
+    // Structures must place into the world before we spend inputs.
+    let placedInteriors: Record<string, import("@/lib/sim/biome-interior").BiomeInterior> | null = null;
+    if (recipe.result.kind === "structure") {
+      if (!interior) return false;
+      const slot = findAdjacentPassable(interior, here.lx, here.ly, 2);
+      if (!slot) return false;
+      const nextInterior = placeObstacle(interior, slot.lx, slot.ly, recipe.result.id);
+      placedInteriors = {
+        ...current.biomeInteriors,
+        [regionKey(here.rx, here.ry)]: nextInterior,
+      };
     }
     if (!affordable(current.inventory, recipe)) return false;
     const nextInventory = spendRecipe(current.inventory, recipe);
@@ -496,7 +510,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
     if (recipe.result.kind === "weapon") {
       const w = makeWeapon(recipe.result.id);
       player = { ...player, weapons: [...player.weapons, w] };
-    } else {
+    } else if (recipe.result.kind === "tool") {
       const t = makeTool(recipe.result.id);
       player = { ...player, tools: [...player.tools, t] };
     }
@@ -505,6 +519,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
         ...current,
         inventory: nextInventory,
         player,
+        biomeInteriors: placedInteriors ?? current.biomeInteriors,
         ticks: current.ticks + recipe.time,
       },
     });


### PR DESCRIPTION
Follow-up to #19 (Phase 4): make the workbench a craftable structure rather than an auto-placed home fixture.

## Summary

- **Hand-station workbench recipe** (`4 wood + 2 stone`, `5` ticks). Tap-craft from the inventory's Quick craft section; it places a workbench at the nearest passable tile within radius 2 of the player.
- **Removed the auto-placement** in `claimHome`. New worlds settle without a workbench — the player has to forage and craft their own. Existing saves that already have a home workbench are unaffected (the bench lives in the saved interior).
- **`RecipeResult` gains a `structure` variant** so future placeables (anvil, kiln, cooking fire) plug into the same crafting path.
- **`findAdjacentPassable` + `placeObstacle` helpers** in `lib/sim/biome-interior.ts`. Deterministic spiral search so placement is stable and rng-free.
- **InventoryPanel Quick craft** uses a new `describeHandResult` helper so weapon and structure recipes both render correctly. The "More at the workbench" copy now reflects that the player has to place one first.

This naturally lifts the prior "just the home workbench" restriction, since players can craft as many as their materials allow.

## Test plan

- [x] `npm run typecheck && npm run lint --max-warnings 0 && npm run build` all pass
- [x] Start a new game, claim a home — **no** workbench placed automatically
- [x] Forage 4 wood + 2 stone, open inventory → Quick craft → Workbench is enabled
- [x] Tap Workbench → world ticks bump by 5; a workbench obstacle appears at a tile adjacent to the player
- [ ] Tap the new workbench → `ObstacleContextMenu` opens with Examine + Craft → tap Craft → `WorkbenchPanel` opens
- [ ] Craft a second workbench in a different region; both remain interactable
- [ ] Verify Quick craft button is greyed when materials are insufficient
- [ ] Vercel preview verified on phone (44px hit targets unchanged)

https://claude.ai/code/session_01XeUfkeDsDekfAifgYPqGHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeUfkeDsDekfAifgYPqGHy)_