### PR TITLE
Phase 5: legacy ledger and per-life state split

### DIFF
--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -10,6 +10,7 @@ import ObstacleContextMenu from "@/components/ObstacleContextMenu";
 import RegionPanel from "@/components/panels/RegionPanel";
 import InventoryPanel from "@/components/panels/InventoryPanel";
 import WorkbenchPanel from "@/components/panels/WorkbenchPanel";
+import PastLivesPanel from "@/components/PastLivesPanel";
 import TutorialModal from "@/components/TutorialModal";
 import RecenterButton from "@/components/RecenterButton";
 import EncounterToast from "@/components/EncounterToast";
@@ -57,6 +58,7 @@ function PlayInner() {
       <RegionPanel />
       <InventoryPanel />
       <WorkbenchPanel />
+      <PastLivesPanel />
       <EncounterToast />
       <EncounterFeed />
       <TutorialModal />

--- a/components/EncounterFeed.tsx
+++ b/components/EncounterFeed.tsx
@@ -3,9 +3,12 @@
 import { CaretRight, Newspaper, X } from "@phosphor-icons/react/dist/ssr";
 import { useState } from "react";
 import { useGameStore } from "@/lib/state/game-store";
+import type { WorldEvent } from "@/lib/sim/events";
+
+const NO_EVENTS: readonly WorldEvent[] = [];
 
 export default function EncounterFeed() {
-  const events = useGameStore((s) => s.world?.recentEvents ?? []);
+  const events = useGameStore((s) => s.world?.recentEvents ?? NO_EVENTS);
   const debugMode = useGameStore((s) => s.debugMode);
   const [open, setOpen] = useState(false);
 

--- a/components/NpcContextMenu.tsx
+++ b/components/NpcContextMenu.tsx
@@ -131,23 +131,26 @@ export default function NpcContextMenu() {
           selectNpc(ctx.id);
           close();
         }}
-        className="tactile inline-flex items-center gap-2 rounded-xl px-2 py-2 text-left text-sm text-[var(--color-fg)] hover:bg-[var(--color-surface-warm)]"
+        className="tactile inline-flex items-center gap-2 rounded-xl bg-[var(--color-surface-warm)] px-2 py-2 text-left text-sm text-[var(--color-fg)] hover:bg-[var(--color-border)]"
       >
         <Eye size={14} weight="duotone" className="text-[var(--color-fg-muted)]" />
         Examine
       </button>
-      {stance !== "Friendly" && (
-        <button
-          onClick={() => {
-            attackNpc(ctx.id);
-            close();
-          }}
-          className="tactile inline-flex items-center gap-2 rounded-xl px-2 py-2 text-left text-sm text-[var(--color-accent)] hover:bg-[var(--color-surface-warm)]"
-        >
-          <Sword size={14} weight="fill" />
-          Attack
-        </button>
-      )}
+      <button
+        onClick={() => {
+          attackNpc(ctx.id);
+          close();
+        }}
+        className="tactile mt-1 inline-flex items-center gap-2 rounded-xl bg-[rgba(217,104,70,0.12)] px-2 py-2 text-left text-sm font-medium text-[var(--color-accent)] hover:bg-[rgba(217,104,70,0.2)]"
+      >
+        <Sword size={14} weight="fill" />
+        Attack
+        {stance === "Friendly" && (
+          <span className="ml-auto font-mono text-[9px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+            friendly
+          </span>
+        )}
+      </button>
     </div>
   );
 }

--- a/components/ObstacleContextMenu.tsx
+++ b/components/ObstacleContextMenu.tsx
@@ -41,7 +41,7 @@ export default function ObstacleContextMenu() {
   const ctx = useGameStore((s) => s.obstacleContextMenu);
   const close = useGameStore((s) => s.closeObstacleContextMenu);
   const interact = useGameStore((s) => s.interactWithObstacle);
-  const player = useGameStore((s) => s.world?.player ?? null);
+  const player = useGameStore((s) => s.world?.life?.player ?? null);
 
   const ref = useRef<HTMLDivElement | null>(null);
   const dragOffset = useRef<{ dx: number; dy: number } | null>(null);

--- a/components/PastLivesPanel.tsx
+++ b/components/PastLivesPanel.tsx
@@ -8,10 +8,12 @@ import ShapeBadge from "@/components/panels/ShapeBadge";
 import type { Legacy } from "@/lib/sim/legacy";
 import type { GameOverReason } from "@/lib/sim/world";
 
+const NO_LEGACIES: readonly Legacy[] = [];
+
 export default function PastLivesPanel() {
   const open = useGameStore((s) => s.pastLivesOpen);
   const close = useGameStore((s) => s.closePastLives);
-  const legacies = useGameStore((s) => s.world?.legacies ?? []);
+  const legacies = useGameStore((s) => s.world?.legacies ?? NO_LEGACIES);
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
   if (!open) return null;

--- a/components/PastLivesPanel.tsx
+++ b/components/PastLivesPanel.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import { Skull, X } from "@phosphor-icons/react/dist/ssr";
+import { useGameStore } from "@/lib/state/game-store";
+import { FACTIONS } from "@/content/factions";
+import ShapeBadge from "@/components/panels/ShapeBadge";
+import type { Legacy } from "@/lib/sim/legacy";
+import type { GameOverReason } from "@/lib/sim/world";
+
+export default function PastLivesPanel() {
+  const open = useGameStore((s) => s.pastLivesOpen);
+  const close = useGameStore((s) => s.closePastLives);
+  const legacies = useGameStore((s) => s.world?.legacies ?? []);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  const ordered = [...legacies].reverse();
+
+  return (
+    <aside
+      role="dialog"
+      aria-label="Past lives"
+      className="pointer-events-auto absolute inset-x-2 bottom-2 z-20 max-h-[68dvh] overflow-y-auto rounded-3xl border border-[var(--color-border)] bg-[var(--color-surface)] p-5 shadow-[0_20px_48px_-20px_rgba(44,40,32,0.25)]"
+    >
+      <div className="mx-auto max-w-2xl">
+        <header className="mb-4 flex items-start justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <span
+              aria-hidden
+              className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-surface-warm)]"
+            >
+              <Skull size={18} weight="duotone" className="text-[var(--color-fg)]" />
+            </span>
+            <div>
+              <h2 className="text-lg font-medium leading-tight text-[var(--color-fg)]">
+                Past lives
+              </h2>
+              <p className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+                {ordered.length === 0
+                  ? "None yet"
+                  : `${ordered.length} remembered`}
+              </p>
+            </div>
+          </div>
+          <button
+            aria-label="Close"
+            onClick={close}
+            className="tactile inline-flex h-9 w-9 items-center justify-center rounded-full text-[var(--color-fg-muted)] hover:bg-[var(--color-surface-warm)] hover:text-[var(--color-fg)]"
+          >
+            <X size={18} weight="bold" />
+          </button>
+        </header>
+
+        {ordered.length === 0 ? (
+          <p className="text-sm text-[var(--color-fg-muted)]">
+            No lives have ended yet. The land is patient.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {ordered.map((legacy) => (
+              <LegacyRow
+                key={legacy.id}
+                legacy={legacy}
+                expanded={expandedId === legacy.id}
+                onToggle={() =>
+                  setExpandedId((cur) => (cur === legacy.id ? null : legacy.id))
+                }
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function LegacyRow({
+  legacy,
+  expanded,
+  onToggle,
+}: {
+  legacy: Legacy;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const faction = FACTIONS.find((f) => f.id === legacy.factionOfOriginId);
+  const factionHex = faction
+    ? "#" + faction.color.toString(16).padStart(6, "0")
+    : "#cccccc";
+  const shape = faction?.shape ?? "diamond";
+  const cause = describeCause(legacy.cause);
+  return (
+    <li>
+      <button
+        onClick={onToggle}
+        aria-expanded={expanded}
+        className="tactile flex w-full items-center gap-3 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-warm)] px-3 py-2 text-left"
+      >
+        <ShapeBadge shape={shape} color={factionHex} />
+        <span className="flex-1 min-w-0">
+          <span className="block truncate text-sm font-medium text-[var(--color-fg)]">
+            {legacy.name}
+          </span>
+          <span className="block font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+            {faction?.name ?? legacy.factionOfOriginId} · {cause}
+          </span>
+        </span>
+        <span className="font-mono text-[11px] tabular-nums text-[var(--color-fg-muted)]">
+          {legacy.ticksAlive}t · {legacy.kills}k
+        </span>
+      </button>
+      {expanded && (
+        <dl className="mt-1 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 rounded-2xl border border-dashed border-[var(--color-border)] px-4 py-3 font-mono text-[11px]">
+          <dt className="text-[var(--color-fg-muted)] uppercase tracking-wider">
+            Born
+          </dt>
+          <dd className="tabular-nums text-[var(--color-fg)]">tick {legacy.bornAtTick}</dd>
+          <dt className="text-[var(--color-fg-muted)] uppercase tracking-wider">
+            Ended
+          </dt>
+          <dd className="tabular-nums text-[var(--color-fg)]">tick {legacy.endedAtTick}</dd>
+          <dt className="text-[var(--color-fg-muted)] uppercase tracking-wider">
+            Lived
+          </dt>
+          <dd className="tabular-nums text-[var(--color-fg)]">{legacy.ticksAlive} ticks</dd>
+          <dt className="text-[var(--color-fg-muted)] uppercase tracking-wider">
+            Regions
+          </dt>
+          <dd className="tabular-nums text-[var(--color-fg)]">{legacy.regionsDiscovered} discovered</dd>
+          <dt className="text-[var(--color-fg-muted)] uppercase tracking-wider">
+            Kills
+          </dt>
+          <dd className="tabular-nums text-[var(--color-fg)]">{legacy.kills}</dd>
+          <dt className="text-[var(--color-fg-muted)] uppercase tracking-wider">
+            Cause
+          </dt>
+          <dd className="text-[var(--color-fg)] normal-case">{cause}</dd>
+        </dl>
+      )}
+    </li>
+  );
+}
+
+function describeCause(reason: GameOverReason): string {
+  if (reason === "starved") return "Starved";
+  return `Killed by ${reason.killerName}`;
+}

--- a/components/RecenterButton.tsx
+++ b/components/RecenterButton.tsx
@@ -7,7 +7,7 @@ import { bus } from "@/lib/render/bus";
 
 export default function RecenterButton() {
   const view = useGameStore((s) => s.view);
-  const gameOver = useGameStore((s) => s.world?.gameOver ?? false);
+  const gameOver = useGameStore((s) => s.world?.life?.gameOver ?? false);
   const [panned, setPanned] = useState(false);
 
   useEffect(() => {

--- a/components/hud/HUD.tsx
+++ b/components/hud/HUD.tsx
@@ -86,13 +86,21 @@ export default function HUD() {
   return (
     <>
       <header className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-start justify-between p-3">
-        <Link
-          href="/"
-          aria-label="Back to menu"
-          className="tactile pointer-events-auto inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
-        >
-          <House size={18} weight="duotone" className="text-[var(--color-fg)]" />
-        </Link>
+        <div className="flex flex-col items-start gap-2">
+          <Link
+            href="/"
+            aria-label="Back to menu"
+            className="tactile pointer-events-auto inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
+          >
+            <House size={18} weight="duotone" className="text-[var(--color-fg)]" />
+          </Link>
+          {player && (
+            <IdentityStrip
+              name={player.name}
+              factionOfOriginId={player.factionOfOriginId}
+            />
+          )}
+        </div>
 
         <div className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] py-1 pl-3.5 pr-1.5 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]">
           <span className="select-none font-mono text-xs tabular-nums text-[var(--color-fg-muted)]">
@@ -201,10 +209,6 @@ export default function HUD() {
 
       {player && (
         <div className="pointer-events-none absolute inset-x-2 top-16 z-10 flex flex-wrap items-center justify-end gap-2">
-          <IdentityStrip
-            name={player.name}
-            factionOfOriginId={player.factionOfOriginId}
-          />
           <HealthStrip health={player.health} max={player.healthMax} inCombat={inCombat} />
           <EnergyStrip energy={player.energy} max={player.energyMax} />
           <InventoryStrip
@@ -396,17 +400,17 @@ function IdentityStrip({
     ? "#" + faction.color.toString(16).padStart(6, "0")
     : "#cccccc";
   return (
-    <div className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] py-1 pl-1.5 pr-3 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]">
+    <div
+      className="pointer-events-auto inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] py-1 pl-1.5 pr-2.5 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
+      title={faction?.name ?? factionOfOriginId}
+    >
       <span
         aria-hidden
-        className="grid h-7 w-7 place-items-center rounded-md border border-[var(--color-border-strong)]"
+        className="h-4 w-4 shrink-0 rounded-sm border border-[var(--color-border-strong)]"
         style={{ background: color }}
       />
-      <span className="flex flex-col leading-tight">
-        <span className="text-xs font-medium text-[var(--color-fg)]">{name}</span>
-        <span className="font-mono text-[9px] uppercase tracking-wider text-[var(--color-fg-muted)]">
-          {faction?.name ?? factionOfOriginId}
-        </span>
+      <span className="text-xs font-medium leading-none text-[var(--color-fg)]">
+        {name}
       </span>
     </div>
   );

--- a/components/hud/HUD.tsx
+++ b/components/hud/HUD.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import {
   Bug,
   Eye,
@@ -86,21 +87,13 @@ export default function HUD() {
   return (
     <>
       <header className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-start justify-between p-3">
-        <div className="flex flex-col items-start gap-2">
-          <Link
-            href="/"
-            aria-label="Back to menu"
-            className="tactile pointer-events-auto inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
-          >
-            <House size={18} weight="duotone" className="text-[var(--color-fg)]" />
-          </Link>
-          {player && (
-            <IdentityStrip
-              name={player.name}
-              factionOfOriginId={player.factionOfOriginId}
-            />
-          )}
-        </div>
+        <Link
+          href="/"
+          aria-label="Back to menu"
+          className="tactile pointer-events-auto inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
+        >
+          <House size={18} weight="duotone" className="text-[var(--color-fg)]" />
+        </Link>
 
         <div className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] py-1 pl-3.5 pr-1.5 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]">
           <span className="select-none font-mono text-xs tabular-nums text-[var(--color-fg-muted)]">
@@ -205,6 +198,13 @@ export default function HUD() {
             Tap a region to claim your home base
           </div>
         </div>
+      )}
+
+      {player && (
+        <IdentityBadge
+          name={player.name}
+          factionOfOriginId={player.factionOfOriginId}
+        />
       )}
 
       {player && (
@@ -388,31 +388,40 @@ function DebugStrip() {
   );
 }
 
-function IdentityStrip({
+function IdentityBadge({
   name,
   factionOfOriginId,
 }: {
   name: string;
   factionOfOriginId: string;
 }) {
+  const [expanded, setExpanded] = useState(false);
   const faction = FACTIONS.find((f) => f.id === factionOfOriginId);
   const color = faction
     ? "#" + faction.color.toString(16).padStart(6, "0")
     : "#cccccc";
+  const factionName = faction?.name ?? factionOfOriginId;
   return (
-    <div
-      className="pointer-events-auto inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] py-1 pl-1.5 pr-2.5 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
-      title={faction?.name ?? factionOfOriginId}
+    <button
+      onClick={() => setExpanded((v) => !v)}
+      aria-label={`You are ${name} of ${factionName}`}
+      title={`${name} · ${factionName}`}
+      className="tactile pointer-events-auto absolute left-2 top-32 z-20 inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] py-1 pl-1 pr-1 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]"
     >
       <span
         aria-hidden
-        className="h-4 w-4 shrink-0 rounded-sm border border-[var(--color-border-strong)]"
+        className="h-6 w-6 shrink-0 rounded-md border border-[var(--color-border-strong)]"
         style={{ background: color }}
       />
-      <span className="text-xs font-medium leading-none text-[var(--color-fg)]">
-        {name}
-      </span>
-    </div>
+      {expanded && (
+        <span className="flex flex-col items-start pr-2 leading-tight">
+          <span className="text-xs font-medium text-[var(--color-fg)]">{name}</span>
+          <span className="font-mono text-[9px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+            {factionName}
+          </span>
+        </span>
+      )}
+    </button>
   );
 }
 

--- a/components/hud/HUD.tsx
+++ b/components/hud/HUD.tsx
@@ -12,12 +12,16 @@ import {
   MapTrifold,
   Lightning,
   Heart,
+  Skull,
 } from "@phosphor-icons/react/dist/ssr";
 import { useGameStore } from "@/lib/state/game-store";
 import { RESOURCES, type ResourceKind } from "@/content/resources";
 import { globalToLocal } from "@/lib/sim/biome-interior";
 import type { GameOverReason } from "@/lib/sim/world";
+import type { Legacy } from "@/lib/sim/legacy";
+import { FACTIONS } from "@/content/factions";
 import { findFaction } from "@/lib/sim/faction";
+import ShapeBadge from "@/components/panels/ShapeBadge";
 import {
   inventoryCapFromBaskets,
   inventoryTotal,
@@ -41,14 +45,21 @@ export default function HUD() {
   const setView = useGameStore((s) => s.setView);
   const homePending = useGameStore((s) => s.homePending);
   const hasHome = useGameStore((s) => Boolean(s.world?.home));
-  const player = useGameStore((s) => s.world?.player ?? null);
-  const inventory = useGameStore((s) => s.world?.inventory ?? {});
-  const gameOver = useGameStore((s) => s.world?.gameOver ?? false);
-  const gameOverReason = useGameStore((s) => s.world?.gameOverReason ?? null);
+  const player = useGameStore((s) => s.world?.life?.player ?? null);
+  const inventory = useGameStore((s) => s.world?.life?.inventory ?? {});
+  const gameOver = useGameStore((s) => s.world?.life?.gameOver ?? false);
+  const gameOverReason = useGameStore((s) => s.world?.life?.gameOverReason ?? null);
+  const lastLegacy = useGameStore((s) => {
+    const legacies = s.world?.legacies;
+    if (!legacies || legacies.length === 0) return null;
+    return legacies[legacies.length - 1] ?? null;
+  });
+  const legacyCount = useGameStore((s) => s.world?.legacies.length ?? 0);
   const inCombat = useGameStore((s) => {
     const w = s.world;
-    if (!w?.player) return false;
-    const here = globalToLocal(w.player.gx, w.player.gy);
+    const p = w?.life?.player;
+    if (!w || !p) return false;
+    const here = globalToLocal(p.gx, p.gy);
     for (const n of w.npcs) {
       if (n.rx !== here.rx || n.ry !== here.ry) continue;
       if ((w.playerReputation[n.factionId] ?? 0) < 0) return true;
@@ -57,11 +68,13 @@ export default function HUD() {
   });
   const killerFactionName = useGameStore((s) => {
     const w = s.world;
-    if (!w || !w.gameOverReason || w.gameOverReason === "starved") return null;
-    return findFaction(w.factions, w.gameOverReason.factionId)?.name ?? null;
+    const reason = w?.life?.gameOverReason;
+    if (!w || !reason || reason === "starved") return null;
+    return findFaction(w.factions, reason.factionId)?.name ?? null;
   });
   const resetAfterDeath = useGameStore((s) => s.resetAfterDeath);
   const openInventory = useGameStore((s) => s.openInventory);
+  const openPastLives = useGameStore((s) => s.openPastLives);
   const debugMode = useGameStore((s) => s.debugMode);
   const toggleDebug = useGameStore((s) => s.toggleDebug);
   const mapShowFactions = useGameStore((s) => s.mapShowFactions);
@@ -146,6 +159,19 @@ export default function HUD() {
             </>
           )}
 
+          {legacyCount > 0 && (
+            <>
+              <span className="mx-1 h-4 w-px bg-[var(--color-border)]" aria-hidden />
+              <button
+                aria-label="Past lives"
+                onClick={openPastLives}
+                className="tactile inline-flex h-8 w-8 items-center justify-center rounded-full text-[var(--color-fg)] hover:bg-[var(--color-surface-warm)]"
+              >
+                <Skull size={16} weight="duotone" />
+              </button>
+            </>
+          )}
+
           <span className="mx-1 h-4 w-px bg-[var(--color-border)]" aria-hidden />
           <button
             aria-label={debugMode ? "Hide debug overlay" : "Show debug overlay"}
@@ -194,16 +220,67 @@ export default function HUD() {
             <p className="mt-3 text-sm leading-relaxed text-[var(--color-fg-muted)] max-w-[34ch] mx-auto">
               {gameOverBody(gameOverReason, killerFactionName)}
             </p>
+            {lastLegacy && <LegacyStats legacy={lastLegacy} />}
             <button
               onClick={resetAfterDeath}
               className="tactile mt-5 inline-flex items-center justify-center rounded-2xl bg-[var(--color-accent)] px-4 py-3 text-sm font-medium text-[var(--color-bg)] shadow-[0_8px_24px_-12px_rgba(217,104,70,0.5)]"
             >
               Begin a new life
             </button>
+            {legacyCount > 0 && (
+              <button
+                onClick={openPastLives}
+                className="tactile mt-2 inline-flex items-center justify-center gap-1.5 rounded-2xl px-3 py-2 font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-muted)] hover:bg-[var(--color-surface-warm)] hover:text-[var(--color-fg)]"
+              >
+                <Skull size={12} weight="duotone" />
+                View past lives
+              </button>
+            )}
           </div>
         </div>
       )}
     </>
+  );
+}
+
+function LegacyStats({ legacy }: { legacy: Legacy }) {
+  const faction = FACTIONS.find((f) => f.id === legacy.factionOfOriginId);
+  const factionHex = faction
+    ? "#" + faction.color.toString(16).padStart(6, "0")
+    : "#cccccc";
+  const shape = faction?.shape ?? "diamond";
+  return (
+    <div className="mt-4 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-warm)] px-4 py-3 text-left">
+      <div className="flex items-center gap-2">
+        <ShapeBadge shape={shape} color={factionHex} />
+        <div>
+          <p className="text-sm font-medium text-[var(--color-fg)]">{legacy.name}</p>
+          <p className="font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+            of {faction?.name ?? legacy.factionOfOriginId}
+          </p>
+        </div>
+      </div>
+      <dl className="mt-3 grid grid-cols-3 gap-2 font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+        <div>
+          <dt>Ticks</dt>
+          <dd className="mt-0.5 font-mono text-base tabular-nums text-[var(--color-fg)]">
+            {legacy.ticksAlive}
+          </dd>
+        </div>
+        <div>
+          <dt>Kills</dt>
+          <dd className="mt-0.5 font-mono text-base tabular-nums text-[var(--color-fg)]">
+            {legacy.kills}
+          </dd>
+        </div>
+        <div>
+          <dt>Regions</dt>
+          <dd className="mt-0.5 font-mono text-base tabular-nums text-[var(--color-fg)]">
+            {legacy.regionsDiscovered}
+          </dd>
+        </div>
+      </dl>
+    </div>
   );
 }
 
@@ -230,7 +307,7 @@ function DebugStrip() {
   const minimized = useGameStore((s) => s.debugMinimized);
   const toggleMinimized = useGameStore((s) => s.toggleDebugMinimized);
   if (!world) return null;
-  const player = world.player;
+  const player = world.life?.player ?? null;
   const here = player ? globalToLocal(player.gx, player.gy) : null;
   const inRegion = here
     ? world.npcs.filter((n) => n.rx === here.rx && n.ry === here.ry).length

--- a/components/hud/HUD.tsx
+++ b/components/hud/HUD.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/lib/sim/tools";
 
 const SPEEDS = [1, 2, 4] as const;
+const EMPTY_INVENTORY: Partial<Record<ResourceKind, number>> = {};
 
 export default function HUD() {
   const paused = useGameStore((s) => s.paused);
@@ -46,7 +47,9 @@ export default function HUD() {
   const homePending = useGameStore((s) => s.homePending);
   const hasHome = useGameStore((s) => Boolean(s.world?.home));
   const player = useGameStore((s) => s.world?.life?.player ?? null);
-  const inventory = useGameStore((s) => s.world?.life?.inventory ?? {});
+  const inventory = useGameStore(
+    (s) => s.world?.life?.inventory ?? EMPTY_INVENTORY,
+  );
   const gameOver = useGameStore((s) => s.world?.life?.gameOver ?? false);
   const gameOverReason = useGameStore((s) => s.world?.life?.gameOverReason ?? null);
   const lastLegacy = useGameStore((s) => {

--- a/components/hud/HUD.tsx
+++ b/components/hud/HUD.tsx
@@ -201,6 +201,10 @@ export default function HUD() {
 
       {player && (
         <div className="pointer-events-none absolute inset-x-2 top-16 z-10 flex flex-wrap items-center justify-end gap-2">
+          <IdentityStrip
+            name={player.name}
+            factionOfOriginId={player.factionOfOriginId}
+          />
           <HealthStrip health={player.health} max={player.healthMax} inCombat={inCombat} />
           <EnergyStrip energy={player.energy} max={player.energyMax} />
           <InventoryStrip
@@ -377,6 +381,34 @@ function DebugStrip() {
         ))}
       </div>
     </aside>
+  );
+}
+
+function IdentityStrip({
+  name,
+  factionOfOriginId,
+}: {
+  name: string;
+  factionOfOriginId: string;
+}) {
+  const faction = FACTIONS.find((f) => f.id === factionOfOriginId);
+  const color = faction
+    ? "#" + faction.color.toString(16).padStart(6, "0")
+    : "#cccccc";
+  return (
+    <div className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] py-1 pl-1.5 pr-3 shadow-[0_4px_12px_-6px_rgba(44,40,32,0.18)]">
+      <span
+        aria-hidden
+        className="grid h-7 w-7 place-items-center rounded-md border border-[var(--color-border-strong)]"
+        style={{ background: color }}
+      />
+      <span className="flex flex-col leading-tight">
+        <span className="text-xs font-medium text-[var(--color-fg)]">{name}</span>
+        <span className="font-mono text-[9px] uppercase tracking-wider text-[var(--color-fg-muted)]">
+          {faction?.name ?? factionOfOriginId}
+        </span>
+      </span>
+    </div>
   );
 }
 

--- a/components/panels/InventoryPanel.tsx
+++ b/components/panels/InventoryPanel.tsx
@@ -19,8 +19,9 @@ export default function InventoryPanel() {
 
   if (!open || !world) return null;
 
-  const inventory = world.inventory;
-  const player = world.player;
+  const inventory = world.life?.inventory ?? {};
+  const player = world.life?.player ?? null;
+  const gameOver = world.life?.gameOver ?? false;
   const entries = (Object.entries(inventory) as Array<[ResourceKind, number]>).filter(
     ([, n]) => n > 0,
   );
@@ -98,7 +99,7 @@ export default function InventoryPanel() {
                     {meta.food && (
                       <button
                         onClick={() => eatFood(kind)}
-                        disabled={!player || world.gameOver}
+                        disabled={!player || gameOver}
                         className="tactile inline-flex items-center gap-1 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1 font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg)] disabled:opacity-50"
                       >
                         <ForkKnife size={12} weight="fill" className="text-[var(--color-accent)]" />
@@ -182,7 +183,7 @@ export default function InventoryPanel() {
             {handRecipes.map((recipe) => {
               const can =
                 Boolean(player) &&
-                !world.gameOver &&
+                !gameOver &&
                 affordable(inventory, recipe);
               const stats = describeHandResult(recipe);
               return (

--- a/components/panels/NpcPanel.tsx
+++ b/components/panels/NpcPanel.tsx
@@ -135,13 +135,13 @@ function NpcPanelInner({
           )}
         </dl>
 
-        {sentiment !== "friendly" && player && (
+        {player && (
           <button
             onClick={onAttack}
             className="tactile mt-4 inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-[var(--color-accent)] px-4 py-3 text-sm font-medium text-[var(--color-bg)] shadow-[0_8px_24px_-12px_rgba(217,104,70,0.5)]"
           >
             <Sword size={16} weight="fill" />
-            Attack
+            {sentiment === "friendly" ? "Attack (friendly)" : "Attack"}
           </button>
         )}
       </div>

--- a/components/panels/NpcPanel.tsx
+++ b/components/panels/NpcPanel.tsx
@@ -24,7 +24,7 @@ export default function NpcPanel() {
     <NpcPanelInner
       npc={npc}
       npcs={world.npcs}
-      player={world.player}
+      player={world.life?.player ?? null}
       playerRep={world.playerReputation[npc.factionId] ?? 0}
       onAttack={() => attackNpc(npc.id)}
     />

--- a/components/panels/RegionPanel.tsx
+++ b/components/panels/RegionPanel.tsx
@@ -33,14 +33,15 @@ export default function RegionPanel() {
   const controllerId = world.regionControl[`${region.rx},${region.ry}`];
   const controller = controllerId ? FACTIONS.find((f) => f.id === controllerId) : undefined;
 
-  const player = world.player;
+  const player = world.life?.player ?? null;
+  const gameOver = world.life?.gameOver ?? false;
   const playerRegion = player ? globalToLocal(player.gx, player.gy) : null;
   const isCurrentRegion =
     playerRegion ? playerRegion.rx === region.rx && playerRegion.ry === region.ry : false;
   const center = regionCenterGlobal(region.rx, region.ry);
   const distance = player ? Math.abs(center.gx - player.gx) + Math.abs(center.gy - player.gy) : 0;
   const reachable = player && meta.passable && distance <= WALK_MAX_RADIUS && !isCurrentRegion;
-  const showTravel = Boolean(player) && meta.passable && !isCurrentRegion && !world.gameOver;
+  const showTravel = Boolean(player) && meta.passable && !isCurrentRegion && !gameOver;
 
   return (
     <aside
@@ -131,7 +132,7 @@ export default function RegionPanel() {
           </button>
         )}
 
-        {debug && Boolean(player) && !isCurrentRegion && meta.passable && !world.gameOver && (
+        {debug && Boolean(player) && !isCurrentRegion && meta.passable && !gameOver && (
           <div className="mt-3 flex flex-wrap gap-2">
             <button
               onClick={() => teleportToRegion(region.rx, region.ry)}

--- a/components/panels/WorkbenchPanel.tsx
+++ b/components/panels/WorkbenchPanel.tsx
@@ -20,11 +20,12 @@ export default function WorkbenchPanel() {
   const world = useGameStore((s) => s.world);
   const craftRecipe = useGameStore((s) => s.craftRecipe);
 
-  if (!open || !world?.player) return null;
+  if (!open || !world?.life) return null;
 
   const recipes = RECIPES.filter((r) => r.station === "workbench");
-  const inventory = world.inventory;
-  const player = world.player;
+  const inventory = world.life.inventory;
+  const player = world.life.player;
+  const gameOver = world.life.gameOver;
   const here = globalToLocal(player.gx, player.gy);
   const interior = world.biomeInteriors[regionKey(here.rx, here.ry)];
   const wb = interior ? findWorkbenchTile(interior) : null;
@@ -71,7 +72,7 @@ export default function WorkbenchPanel() {
               recipe={recipe}
               inventory={inventory}
               adjacent={adjacent}
-              gameOver={world.gameOver}
+              gameOver={gameOver}
               onCraft={() => craftRecipe(recipe.id)}
             />
           ))}

--- a/lib/render/scenes/BiomeScene.ts
+++ b/lib/render/scenes/BiomeScene.ts
@@ -641,10 +641,13 @@ export class BiomeScene extends Phaser.Scene {
       6,
     );
     this.playerLayer.clear();
+    const player = useGameStore.getState().world?.life?.player;
+    const factionColor =
+      FACTIONS.find((f) => f.id === player?.factionOfOriginId)?.color ?? COLORS.player;
     drawFactionShape(
       this.playerLayer,
       "square",
-      COLORS.player,
+      factionColor,
       this.playerCx,
       this.playerCy,
       PLAYER_SIZE,

--- a/lib/render/scenes/BiomeScene.ts
+++ b/lib/render/scenes/BiomeScene.ts
@@ -124,7 +124,7 @@ export class BiomeScene extends Phaser.Scene {
     this.visitorHits = [];
     bus.emit("biome:panned", { panned: false });
 
-    const player = useGameStore.getState().world?.player;
+    const player = useGameStore.getState().world?.life?.player;
     if (player) {
       this.playerGx = player.gx;
       this.playerGy = player.gy;
@@ -163,7 +163,7 @@ export class BiomeScene extends Phaser.Scene {
       this.scene.start("World");
       return;
     }
-    if (!store.paused && !store.world?.gameOver) {
+    if (!store.paused && !store.world?.life?.gameOver) {
       this.accumulator += delta * store.speed;
       while (this.accumulator >= this.tickStepMs) {
         this.accumulator -= this.tickStepMs;
@@ -175,8 +175,8 @@ export class BiomeScene extends Phaser.Scene {
 
   private renderFrame() {
     const world = useGameStore.getState().world;
-    if (!world || !world.player) return;
-    const player = world.player;
+    if (!world || !world.life) return;
+    const player = world.life.player;
     const now = this.time.now;
 
     if (player.gx !== this.playerGx || player.gy !== this.playerGy) {
@@ -211,9 +211,9 @@ export class BiomeScene extends Phaser.Scene {
     this.drawRoute(player);
     this.drawPlayer();
     this.drawVisitors(world.npcs, world);
-    this.detectHits(world.npcs, world.player.health);
-    this.spawnPickupTexts(world.recentPickups);
-    this.drawProjectiles(world.recentProjectiles, world.ticks);
+    this.detectHits(world.npcs, player.health);
+    this.spawnPickupTexts(world.life.recentPickups);
+    this.drawProjectiles(world.life.recentProjectiles, world.ticks);
     this.drawSelection();
   }
 
@@ -653,7 +653,7 @@ export class BiomeScene extends Phaser.Scene {
   }
 
   private drawVisitors(npcs: Npc[], world: { ticks: number }) {
-    const player = useGameStore.getState().world?.player;
+    const player = useGameStore.getState().world?.life?.player;
     if (!player) return;
     const here = globalToLocal(player.gx, player.gy);
     const visitors = npcs.filter((n) => n.rx === here.rx && n.ry === here.ry);
@@ -747,7 +747,7 @@ export class BiomeScene extends Phaser.Scene {
   }
 
   private gameOver(): boolean {
-    return useGameStore.getState().world?.gameOver ?? false;
+    return useGameStore.getState().world?.life?.gameOver ?? false;
   }
 
   private setCameraPanned(panned: boolean) {

--- a/lib/render/scenes/WorldScene.ts
+++ b/lib/render/scenes/WorldScene.ts
@@ -139,7 +139,7 @@ export class WorldScene extends Phaser.Scene {
       this.scene.start("Biome");
       return;
     }
-    if (!store.paused && !store.world?.gameOver) {
+    if (!store.paused && !store.world?.life?.gameOver) {
       this.accumulator += delta * store.speed;
       while (this.accumulator >= this.tickStepMs) {
         this.accumulator -= this.tickStepMs;
@@ -486,7 +486,7 @@ export class WorldScene extends Phaser.Scene {
   }
 
   private renderPlayerHere() {
-    const player = useGameStore.getState().world?.player;
+    const player = useGameStore.getState().world?.life?.player;
     this.playerHere.clear();
     if (!player) {
       this.playerHere.setVisible(false);
@@ -621,7 +621,7 @@ export class WorldScene extends Phaser.Scene {
   };
 
   private gameOver(): boolean {
-    return useGameStore.getState().world?.gameOver ?? false;
+    return useGameStore.getState().world?.life?.gameOver ?? false;
   }
 
   private onPointerDown(pointer: Phaser.Input.Pointer) {

--- a/lib/render/scenes/WorldScene.ts
+++ b/lib/render/scenes/WorldScene.ts
@@ -587,6 +587,7 @@ export class WorldScene extends Phaser.Scene {
     });
     this.playerHere.setVisible(true);
 
+    this.playerLabel.setText(player.name);
     this.playerLabel.setPosition(cx, cy + playerSize / 2 + 2);
     this.playerLabel.setVisible(true);
   }

--- a/lib/render/scenes/WorldScene.ts
+++ b/lib/render/scenes/WorldScene.ts
@@ -579,7 +579,9 @@ export class WorldScene extends Phaser.Scene {
       playerSize,
       5,
     );
-    drawFactionShape(this.playerHere, "square", COLORS.player, cx, cy, playerSize, {
+    const factionColor =
+      FACTIONS.find((f) => f.id === player.factionOfOriginId)?.color ?? COLORS.player;
+    drawFactionShape(this.playerHere, "square", factionColor, cx, cy, playerSize, {
       stroke: 2,
       strokeColor: COLORS.outline,
     });

--- a/lib/sim/legacy.ts
+++ b/lib/sim/legacy.ts
@@ -1,0 +1,39 @@
+import type { Rng } from "@/lib/sim/rng";
+import type { GameOverReason } from "@/lib/sim/world";
+import { NAMES } from "@/content/traits";
+import { FACTIONS } from "@/content/factions";
+
+export type Legacy = {
+  id: string;
+  name: string;
+  factionOfOriginId: string;
+  bornAtTick: number;
+  endedAtTick: number;
+  ticksAlive: number;
+  regionsDiscovered: number;
+  kills: number;
+  cause: GameOverReason;
+};
+
+export function pickLifeName(rng: Rng, takenNames: readonly string[]): string {
+  const taken = new Set(takenNames);
+  const free = NAMES.filter((n) => !taken.has(n));
+  const pool = free.length > 0 ? free : NAMES;
+  return rng.pick(pool);
+}
+
+export function pickFactionOfOrigin(rng: Rng): string {
+  return rng.pick(FACTIONS).id;
+}
+
+export function decayReputation(
+  rep: Record<string, number>,
+  factor: number,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const [k, v] of Object.entries(rep)) {
+    const next = Math.trunc(v * factor);
+    if (next !== 0) out[k] = next;
+  }
+  return out;
+}

--- a/lib/sim/player.ts
+++ b/lib/sim/player.ts
@@ -25,6 +25,8 @@ export type PendingAction =
     };
 
 export type Player = {
+  name: string;
+  factionOfOriginId: string;
   gx: number;
   gy: number;
   energy: number;
@@ -55,8 +57,13 @@ export const STARVE_TICKS_PER_DAMAGE = 80;
 export const EAT_ENERGY_PER_FOOD = 3;
 export const EAT_HEALTH_PER_FOOD = 1;
 
-export function createPlayer(spawn: { gx: number; gy: number }): Player {
+export function createPlayer(
+  spawn: { gx: number; gy: number },
+  identity: { name: string; factionOfOriginId: string },
+): Player {
   return {
+    name: identity.name,
+    factionOfOriginId: identity.factionOfOriginId,
     gx: spawn.gx,
     gy: spawn.gy,
     energy: ENERGY_MAX,

--- a/lib/sim/world.ts
+++ b/lib/sim/world.ts
@@ -1,4 +1,4 @@
-import { createRng } from "@/lib/sim/rng";
+import { createRng, type Rng } from "@/lib/sim/rng";
 import { initialFactions, findFaction, type FactionState } from "@/lib/sim/faction";
 import { spawnNpc, tickNpc, type Npc } from "@/lib/sim/npc";
 import {
@@ -20,13 +20,21 @@ import { tickPlayer } from "@/lib/sim/player-tick";
 import type { Inventory } from "@/lib/sim/inventory";
 import { biomeAt, isPassable, type Biome } from "@/lib/sim/biome";
 import { tickCombat } from "@/lib/sim/combat";
+import {
+  decayReputation,
+  pickFactionOfOrigin,
+  pickLifeName,
+  type Legacy,
+} from "@/lib/sim/legacy";
+import { FACTIONS } from "@/content/factions";
 
 export { biomeAt, isPassable, type Biome } from "@/lib/sim/biome";
 
-export const WORLD_VERSION = 9;
+export const WORLD_VERSION = 10;
 export const MAP_W = 32;
 export const MAP_H = 32;
 export const NPC_COUNT = 200;
+export const REPUTATION_DECAY_ON_REBIRTH = 0.5;
 // Presence accumulates per tick and decays slowly so faction zones develop
 // and persist a while after NPCs leave. Tuned so a single NPC sitting on a
 // region for ~5 ticks (~1.25s at 1x) crosses the control threshold, and a
@@ -57,6 +65,21 @@ export type ProjectileFx = {
   color: number;
 };
 
+// Per-life state. Dropped wholesale on death and rebuilt by beginNewLife.
+// Persistent world data (npcs, factions, biomeInteriors, regionControl,
+// playerReputation, legacies, etc.) lives at the top level on World.
+export type LifeState = {
+  player: Player;
+  inventory: Inventory;
+  bornAtTick: number;
+  kills: number;
+  discoveredThisLife: Record<string, true>;
+  recentPickups: PickupNotice[];
+  recentProjectiles: ProjectileFx[];
+  gameOver: boolean;
+  gameOverReason: GameOverReason | null;
+};
+
 export type World = {
   version: number;
   seed: number;
@@ -65,10 +88,8 @@ export type World = {
   npcs: Npc[];
   factions: FactionState[];
   recentEvents: WorldEvent[];
-  player: Player | null;
   home: { rx: number; ry: number } | null;
   biomeInteriors: Record<string, BiomeInterior>;
-  inventory: Inventory;
   // regionKey -> factionId -> presence count (sparse)
   regionPresence: Record<string, Partial<Record<string, number>>>;
   // regionKey -> factionId of the faction currently controlling this region
@@ -77,20 +98,18 @@ export type World = {
   // on the world map; for Phase 1 it's just bookkeeping.
   discoveredRegions: Record<string, true>;
   // factionId -> per-player reputation. Drives hostile/friendly encounters.
+  // Halved on rebirth so past misdeeds linger but don't doom the new life.
   playerReputation: Record<string, number>;
   // pairKey(a,b) -> faction-vs-faction relation. Negative = hostile.
   factionRelations: Record<string, number>;
-  // Ring buffer of recent player pickups (resources + loot). Ephemeral —
-  // BiomeScene drains them to spawn floating text and they fall off after
-  // a short window.
-  recentPickups: PickupNotice[];
-  // Same idea for ranged projectile fx — short-lived dotted-line shots.
-  recentProjectiles: ProjectileFx[];
   // factionId -> last tick at which a member was attacked. Friendlies of
   // an aggrieved faction flee from the player while this is fresh.
   recentFactionAttacks: Record<string, number>;
-  gameOver: boolean;
-  gameOverReason: GameOverReason | null;
+  // Append-only ledger of completed lives.
+  legacies: Legacy[];
+  // The current life (or null if nobody lives — pre-first-claim or between
+  // game-over and rebirth).
+  life: LifeState | null;
 };
 
 export function createWorld(seed = Date.now() & 0xffffffff): World {
@@ -105,20 +124,16 @@ export function createWorld(seed = Date.now() & 0xffffffff): World {
     npcs,
     factions: initialFactions(),
     recentEvents: [],
-    player: null,
     home: null,
     biomeInteriors: {},
-    inventory: {},
     regionPresence: {},
     regionControl: {},
     discoveredRegions: {},
     playerReputation: {},
     factionRelations: {},
-    recentPickups: [],
-    recentProjectiles: [],
     recentFactionAttacks: {},
-    gameOver: false,
-    gameOverReason: null,
+    legacies: [],
+    life: null,
   };
 }
 
@@ -144,6 +159,28 @@ export function ensureInteriorsForRegion(world: World, rx: number, ry: number): 
   return { ...world, biomeInteriors: next };
 }
 
+function takenNpcNames(npcs: Npc[]): string[] {
+  return npcs.map((n) => n.name);
+}
+
+function makeLife(
+  spawn: { gx: number; gy: number },
+  identity: { name: string; factionOfOriginId: string },
+  bornAtTick: number,
+): LifeState {
+  return {
+    player: createPlayer(spawn, identity),
+    inventory: {},
+    bornAtTick,
+    kills: 0,
+    discoveredThisLife: {},
+    recentPickups: [],
+    recentProjectiles: [],
+    gameOver: false,
+    gameOverReason: null,
+  };
+}
+
 export function claimHome(world: World, rx: number, ry: number): World | null {
   if (!isPassable(rx, ry, MAP_W, MAP_H)) return null;
   const biome: Biome = biomeAt(rx, ry);
@@ -155,14 +192,144 @@ export function claimHome(world: World, rx: number, ry: number): World | null {
   if (!interior) return null;
 
   const spawn = nudgeToOpen(seeded, center.gx, center.gy);
-  const player = createPlayer(spawn);
-  const discoveredRegions = { ...seeded.discoveredRegions, [regionKey(rx, ry)]: true as const };
+  const rng = createRng(seeded.rngState);
+  const identity = {
+    name: pickLifeName(rng, takenNpcNames(seeded.npcs)),
+    factionOfOriginId: pickFactionOfOrigin(rng),
+  };
+  const life = makeLife(spawn, identity, seeded.ticks);
+  const homeKey = regionKey(rx, ry);
+  const discoveredRegions = { ...seeded.discoveredRegions, [homeKey]: true as const };
   return {
     ...seeded,
-    player,
+    rngState: rng.state(),
     home: { rx, ry },
     discoveredRegions,
+    life: { ...life, discoveredThisLife: { [homeKey]: true as const } },
   };
+}
+
+// Build the next life on top of the existing world. Called after a death
+// when the player taps "Begin a new life". Picks a deterministic spawn
+// (home if friendly, else nearest passable friendly-or-neutral region —
+// preferring regions with a wandering NPC of the new player's faction-of-
+// origin), halves player reputation, and assigns a fresh name + faction.
+export function beginNewLife(world: World): World {
+  const rng = createRng(world.rngState);
+  const identity = {
+    name: pickLifeName(rng, takenNpcNames(world.npcs)),
+    factionOfOriginId: pickFactionOfOrigin(rng),
+  };
+  const playerReputation = decayReputation(
+    world.playerReputation,
+    REPUTATION_DECAY_ON_REBIRTH,
+  );
+
+  let seeded = world;
+  let spawnRegion: { rx: number; ry: number } | null = null;
+  const home = seeded.home;
+  if (home) {
+    seeded = ensureInteriorsForRegion(seeded, home.rx, home.ry);
+    if (!isHostileRegion(seeded, home.rx, home.ry, playerReputation)) {
+      spawnRegion = home;
+    }
+  }
+  if (!spawnRegion) {
+    const wandering = pickWanderingFactionRegion(seeded, identity.factionOfOriginId);
+    if (wandering) spawnRegion = wandering;
+  }
+  if (!spawnRegion) {
+    const fallback =
+      nearestFriendlyRegion(seeded, seeded.home ?? { rx: 0, ry: 0 }, playerReputation) ??
+      seeded.home ??
+      pickAnyPassableRegion(seeded);
+    spawnRegion = fallback;
+  }
+
+  seeded = ensureInteriorsForRegion(seeded, spawnRegion.rx, spawnRegion.ry);
+  const center = regionCenterGlobal(spawnRegion.rx, spawnRegion.ry);
+  const spawn = nudgeToOpen(seeded, center.gx, center.gy);
+  const life = makeLife(spawn, identity, seeded.ticks);
+  const spawnKey = regionKey(spawnRegion.rx, spawnRegion.ry);
+  return {
+    ...seeded,
+    rngState: rng.state(),
+    playerReputation,
+    discoveredRegions: { ...seeded.discoveredRegions, [spawnKey]: true as const },
+    life: { ...life, discoveredThisLife: { [spawnKey]: true as const } },
+  };
+}
+
+function isHostileRegion(
+  world: World,
+  rx: number,
+  ry: number,
+  rep: Record<string, number>,
+): boolean {
+  const controllerId = world.regionControl[regionKey(rx, ry)];
+  if (!controllerId) return false;
+  if ((rep[controllerId] ?? 0) < 0) return true;
+  const def = FACTIONS.find((f) => f.id === controllerId);
+  if (def?.values.includes("violence")) return true;
+  return false;
+}
+
+function pickWanderingFactionRegion(
+  world: World,
+  factionId: string,
+): { rx: number; ry: number } | null {
+  for (const n of world.npcs) {
+    if (n.factionId !== factionId) continue;
+    if (!isPassable(n.rx, n.ry, MAP_W, MAP_H)) continue;
+    return { rx: n.rx, ry: n.ry };
+  }
+  return null;
+}
+
+function nearestFriendlyRegion(
+  world: World,
+  from: { rx: number; ry: number },
+  rep: Record<string, number>,
+): { rx: number; ry: number } | null {
+  const seen = new Set<string>();
+  const queue: Array<{ rx: number; ry: number }> = [{ rx: from.rx, ry: from.ry }];
+  seen.add(regionKey(from.rx, from.ry));
+  while (queue.length > 0) {
+    const cur = queue.shift()!;
+    if (
+      isPassable(cur.rx, cur.ry, MAP_W, MAP_H) &&
+      biomeAt(cur.rx, cur.ry) !== "water" &&
+      !isHostileRegion(world, cur.rx, cur.ry, rep)
+    ) {
+      return cur;
+    }
+    for (const [dx, dy] of [
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1],
+    ] as const) {
+      const nx = cur.rx + dx;
+      const ny = cur.ry + dy;
+      if (nx < 0 || ny < 0 || nx >= MAP_W || ny >= MAP_H) continue;
+      const k = regionKey(nx, ny);
+      if (seen.has(k)) continue;
+      seen.add(k);
+      queue.push({ rx: nx, ry: ny });
+    }
+  }
+  return null;
+}
+
+function pickAnyPassableRegion(world: World): { rx: number; ry: number } {
+  for (let ry = 0; ry < MAP_H; ry++) {
+    for (let rx = 0; rx < MAP_W; rx++) {
+      if (isPassable(rx, ry, MAP_W, MAP_H) && biomeAt(rx, ry) !== "water") {
+        return { rx, ry };
+      }
+    }
+  }
+  return { rx: 0, ry: 0 };
 }
 
 export function tickWorld(world: World): {
@@ -170,10 +337,11 @@ export function tickWorld(world: World): {
   event: WorldEvent | null;
   workbenchOpened: boolean;
 } {
-  if (world.gameOver) return { world, event: null, workbenchOpened: false };
+  if (world.life?.gameOver) return { world, event: null, workbenchOpened: false };
 
   const rng = createRng(world.rngState);
-  const playerRegion = world.player ? globalToLocal(world.player.gx, world.player.gy) : null;
+  const life = world.life;
+  const playerRegion = life ? globalToLocal(life.player.gx, life.player.gy) : null;
   const ticks = world.ticks + 1;
   const tickCtx = {
     rng,
@@ -188,22 +356,24 @@ export function tickWorld(world: World): {
   };
   let npcs = world.npcs.map((n) => tickNpc(n, tickCtx));
 
-  let player = world.player;
+  let player: Player | null = life?.player ?? null;
+  let inventory: Inventory = life?.inventory ?? {};
   let interiors = world.biomeInteriors;
-  let inventory = world.inventory;
   let factions = world.factions;
   let factionRelations = world.factionRelations;
   let playerReputation = world.playerReputation;
-  let recentPickups = prunePickups(world.recentPickups, ticks);
-  let recentProjectiles = pruneProjectiles(world.recentProjectiles, ticks);
+  let recentPickups = prunePickups(life?.recentPickups ?? [], ticks);
+  let recentProjectiles = pruneProjectiles(life?.recentProjectiles ?? [], ticks);
   let recentFactionAttacks = world.recentFactionAttacks;
   const combatDeathEvents: WorldEvent[] = [];
-  let gameOver: boolean = world.gameOver;
-  let gameOverReason: GameOverReason | null = world.gameOverReason;
+  let gameOver = false;
+  let gameOverReason: GameOverReason | null = null;
   let discoveredRegions = world.discoveredRegions;
+  let discoveredThisLife = life?.discoveredThisLife ?? {};
+  let kills = life?.kills ?? 0;
   let workbenchOpened = false;
 
-  if (player) {
+  if (player && life) {
     const stepped = tickPlayer({
       player,
       interiors,
@@ -289,6 +459,9 @@ export function tickWorld(world: World): {
     if (!discoveredRegions[key]) {
       discoveredRegions = { ...discoveredRegions, [key]: true as const };
     }
+    if (!discoveredThisLife[key]) {
+      discoveredThisLife = { ...discoveredThisLife, [key]: true as const };
+    }
     interiors = ensureNeighbors(interiors, world.seed, cur.rx, cur.ry);
   }
 
@@ -345,6 +518,7 @@ export function tickWorld(world: World): {
             ? `You killed ${d.name}.`
             : `${killer}killed ${d.name}.`,
       });
+      if (d.killerKind === "player") kills += 1;
     }
     // Remove dead NPCs from the canonical list.
     npcs = npcs.filter((n) => n.combatHealth > 0);
@@ -362,26 +536,68 @@ export function tickWorld(world: World): {
     combatDeathEvents.length > 0
       ? [...combatDeathEvents, ...world.recentEvents].slice(0, 8)
       : world.recentEvents;
+
+  let nextLife: LifeState | null = null;
+  let nextLegacies = world.legacies;
+  if (life) {
+    if (gameOver && player) {
+      const cause = gameOverReason!;
+      nextLife = {
+        ...life,
+        player,
+        inventory,
+        recentPickups,
+        recentProjectiles,
+        kills,
+        discoveredThisLife,
+        gameOver: true,
+        gameOverReason: cause,
+      };
+      nextLegacies = [
+        ...world.legacies,
+        {
+          id: `life-${ticks}-${life.player.name}`,
+          name: life.player.name,
+          factionOfOriginId: life.player.factionOfOriginId,
+          bornAtTick: life.bornAtTick,
+          endedAtTick: ticks,
+          ticksAlive: Math.max(0, ticks - life.bornAtTick),
+          regionsDiscovered: Object.keys(discoveredThisLife).length,
+          kills,
+          cause,
+        },
+      ];
+    } else if (player) {
+      nextLife = {
+        ...life,
+        player,
+        inventory,
+        recentPickups,
+        recentProjectiles,
+        kills,
+        discoveredThisLife,
+        gameOver: false,
+        gameOverReason: null,
+      };
+    }
+  }
+
   const next: World = {
     ...world,
     ticks,
     npcs,
     rngState: rng.state(),
-    player,
     biomeInteriors: interiors,
-    inventory,
     regionPresence,
     regionControl,
     discoveredRegions,
     factions,
     factionRelations,
     playerReputation,
-    recentPickups,
-    recentProjectiles,
     recentFactionAttacks,
     recentEvents: startingEvents,
-    gameOver,
-    gameOverReason,
+    legacies: nextLegacies,
+    life: nextLife,
   };
 
   let encounter: WorldEvent | null = null;
@@ -462,7 +678,7 @@ function detectEncounter(
   nextNpcs: Npc[],
   world: World,
   playerRegion: { rx: number; ry: number; lx: number; ly: number },
-  rng: import("@/lib/sim/rng").Rng,
+  rng: Rng,
 ): WorldEvent | null {
   const prevById = new Map<string, Npc>();
   for (const p of prevNpcs) prevById.set(p.id, p);

--- a/lib/state/game-store.ts
+++ b/lib/state/game-store.ts
@@ -2,6 +2,7 @@
 
 import { create } from "zustand";
 import {
+  beginNewLife,
   claimHome as claimHomeWorld,
   createWorld,
   ensureInteriorsForRegion,
@@ -9,6 +10,7 @@ import {
   WORLD_VERSION,
   MAP_W,
   MAP_H,
+  type LifeState,
   type World,
 } from "@/lib/sim/world";
 import { loadWorld, saveWorld } from "@/lib/save/db";
@@ -33,7 +35,6 @@ import {
 import { bfsPredicate } from "@/lib/sim/path";
 import { chebyshev } from "@/lib/sim/combat";
 import type { PendingAction, Player } from "@/lib/sim/player";
-import { createPlayer } from "@/lib/sim/player";
 import { setPendingAttack } from "@/lib/sim/player-tick";
 import {
   affordable,
@@ -73,6 +74,7 @@ type GameStore = {
   homePending: boolean;
   inventoryOpen: boolean;
   workbenchOpen: boolean;
+  pastLivesOpen: boolean;
   tutorialOpen: boolean;
   debugMode: boolean;
   debugMinimized: boolean;
@@ -113,6 +115,8 @@ type GameStore = {
   closeInventory: () => void;
   openWorkbench: () => void;
   closeWorkbench: () => void;
+  openPastLives: () => void;
+  closePastLives: () => void;
   openTutorial: () => void;
   closeTutorial: () => void;
   toggleDebug: () => void;
@@ -135,6 +139,15 @@ type GameStore = {
   inspectBiome: (rx: number, ry: number) => void;
 };
 
+function withLife(world: World, life: LifeState): World {
+  return { ...world, life };
+}
+
+function withPlayer(world: World, player: Player): World | null {
+  if (!world.life) return null;
+  return withLife(world, { ...world.life, player });
+}
+
 export const useGameStore = create<GameStore>((set, get) => ({
   world: null,
   paused: false,
@@ -146,6 +159,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
   homePending: false,
   inventoryOpen: false,
   workbenchOpen: false,
+  pastLivesOpen: false,
   tutorialOpen: false,
   debugMode: false,
   debugMinimized: false,
@@ -164,6 +178,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
       homePending: true,
       inventoryOpen: false,
       workbenchOpen: false,
+      pastLivesOpen: false,
       tutorialOpen: true,
       npcContextMenu: null,
       obstacleContextMenu: null,
@@ -197,12 +212,15 @@ export const useGameStore = create<GameStore>((set, get) => ({
       world,
       lastEvent: event ?? get().lastEvent,
     };
-    if (world.gameOver && !current.gameOver) patch.paused = true;
+    const wasOver = current.life?.gameOver ?? false;
+    const isOver = world.life?.gameOver ?? false;
+    if (isOver && !wasOver) patch.paused = true;
     if (workbenchOpened) {
       patch.workbenchOpen = true;
       patch.selectedNpcId = null;
       patch.selectedRegion = null;
       patch.inventoryOpen = false;
+      patch.pastLivesOpen = false;
       patch.npcContextMenu = null;
       patch.obstacleContextMenu = null;
     }
@@ -221,6 +239,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
       selectedRegion: id ? null : get().selectedRegion,
       obstacleContextMenu: id ? null : get().obstacleContextMenu,
       workbenchOpen: id ? false : get().workbenchOpen,
+      pastLivesOpen: id ? false : get().pastLivesOpen,
     });
     if (!id) bus.emit("npc:deselected");
   },
@@ -230,6 +249,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
       selectedNpcId: region ? null : get().selectedNpcId,
       obstacleContextMenu: region ? null : get().obstacleContextMenu,
       workbenchOpen: region ? false : get().workbenchOpen,
+      pastLivesOpen: region ? false : get().pastLivesOpen,
     });
     if (region) bus.emit("npc:deselected");
   },
@@ -264,10 +284,9 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   walkPlayerTo: (gx, gy) => {
     const current = get().world;
-    if (!current || !current.player) return;
-    if (current.gameOver) return;
+    if (!current?.life || current.life.gameOver) return;
 
-    const startingPlayer: Player = current.player;
+    const startingPlayer: Player = current.life.player;
     let world = current;
     const src = globalToLocal(startingPlayer.gx, startingPlayer.gy);
     const dst = globalToLocal(gx, gy);
@@ -316,12 +335,13 @@ export const useGameStore = create<GameStore>((set, get) => ({
         }
       : { ...startingPlayer, pendingAction: null };
 
-    set({ world: { ...world, player } });
+    const next = withPlayer(world, player);
+    if (next) set({ world: next });
   },
 
   travelToRegion: (rx, ry) => {
     const w = get().world;
-    if (!w?.player || w.gameOver) return;
+    if (!w?.life || w.life.gameOver) return;
     set({
       view: "biome",
       selectedNpcId: null,
@@ -336,7 +356,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   interactWithObstacle: (rx, ry, lx, ly, action) => {
     const current = get().world;
-    if (!current?.player || current.gameOver) return;
+    if (!current?.life || current.life.gameOver) return;
     let world = ensureInteriorsForRegion(current, rx, ry);
     const interior = world.biomeInteriors[regionKey(rx, ry)];
     if (!interior) return;
@@ -346,7 +366,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
       return;
     }
 
-    const startingPlayer = world.player!;
+    const startingPlayer = world.life!.player;
     const isObstacle = (tgx: number, tgy: number): boolean => {
       const loc = globalToLocal(tgx, tgy);
       if (loc.rx < 0 || loc.ry < 0 || loc.rx >= MAP_W || loc.ry >= MAP_H) return true;
@@ -404,8 +424,10 @@ export const useGameStore = create<GameStore>((set, get) => ({
       stepCooldown: bestPath.length === 0 ? 0 : Math.max(1, startingPlayer.stats.speed),
       pendingAction,
     };
+    const next = withPlayer(world, player);
+    if (!next) return;
     set({
-      world: { ...world, player },
+      world: next,
       obstacleContextMenu: null,
       npcContextMenu: null,
     });
@@ -425,27 +447,16 @@ export const useGameStore = create<GameStore>((set, get) => ({
         homePending: true,
         inventoryOpen: false,
         workbenchOpen: false,
+        pastLivesOpen: false,
         tutorialOpen: false,
         npcContextMenu: null,
         obstacleContextMenu: null,
       });
       return;
     }
-    const center = regionCenterGlobal(current.home.rx, current.home.ry);
-    const seeded = ensureInteriorsForRegion(current, current.home.rx, current.home.ry);
-    const interior = seeded.biomeInteriors[regionKey(current.home.rx, current.home.ry)];
-    const spawn = interior
-      ? nearestPassable(interior, center.gx, center.gy, current.home.rx, current.home.ry)
-      : center;
-    const fresh = createPlayer(spawn);
+    const next = beginNewLife(current);
     set({
-      world: {
-        ...seeded,
-        player: fresh,
-        gameOver: false,
-        gameOverReason: null,
-        recentPickups: [],
-      },
+      world: next,
       selectedNpcId: null,
       selectedRegion: null,
       lastEvent: null,
@@ -454,6 +465,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
       homePending: false,
       inventoryOpen: false,
       workbenchOpen: false,
+      pastLivesOpen: false,
       tutorialOpen: false,
       npcContextMenu: null,
       obstacleContextMenu: null,
@@ -463,7 +475,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
   acceptEncounter: () => {
     const current = get().world;
     const event = get().lastEvent;
-    if (!current || !event?.encounter) {
+    if (!current?.life || !event?.encounter) {
       set({ lastEvent: null });
       return;
     }
@@ -472,23 +484,31 @@ export const useGameStore = create<GameStore>((set, get) => ({
       set({ lastEvent: null });
       return;
     }
-    let inventory = current.inventory;
+    let inventory = current.life.inventory;
     if (enc.offer) {
       const prev = inventory[enc.offer.kind] ?? 0;
       inventory = { ...inventory, [enc.offer.kind]: prev + enc.offer.amount };
     }
     const playerReputation = gainPlayerRep(current.playerReputation, enc.factionId, 2);
-    set({ world: { ...current, inventory, playerReputation }, lastEvent: null });
+    set({
+      world: {
+        ...current,
+        playerReputation,
+        life: { ...current.life, inventory },
+      },
+      lastEvent: null,
+    });
   },
 
   dismissEncounter: () => set({ lastEvent: null }),
 
   craftRecipe: (recipeId) => {
     const current = get().world;
-    if (!current?.player || current.gameOver) return false;
+    if (!current?.life || current.life.gameOver) return false;
     const recipe = RECIPES_BY_ID[recipeId];
     if (!recipe) return false;
-    const here = globalToLocal(current.player.gx, current.player.gy);
+    const life = current.life;
+    const here = globalToLocal(life.player.gx, life.player.gy);
     const interior = current.biomeInteriors[regionKey(here.rx, here.ry)];
     if (recipe.station === "workbench") {
       if (!interior) return false;
@@ -507,10 +527,10 @@ export const useGameStore = create<GameStore>((set, get) => ({
         [regionKey(here.rx, here.ry)]: nextInterior,
       };
     }
-    if (!affordable(current.inventory, recipe)) return false;
-    const nextInventory = spendRecipe(current.inventory, recipe);
+    if (!affordable(life.inventory, recipe)) return false;
+    const nextInventory = spendRecipe(life.inventory, recipe);
     if (!nextInventory) return false;
-    let player: Player = current.player;
+    let player: Player = life.player;
     if (recipe.result.kind === "weapon") {
       const w = makeWeapon(recipe.result.id);
       player = { ...player, weapons: [...player.weapons, w] };
@@ -521,10 +541,9 @@ export const useGameStore = create<GameStore>((set, get) => ({
     set({
       world: {
         ...current,
-        inventory: nextInventory,
-        player,
         biomeInteriors: placedInteriors ?? current.biomeInteriors,
         ticks: current.ticks + recipe.time,
+        life: { ...life, player, inventory: nextInventory },
       },
     });
     return true;
@@ -532,15 +551,16 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   attackNpc: (id) => {
     const current = get().world;
-    if (!current?.player || current.gameOver) return;
-    const player = setPendingAttack(current.player, id);
-    set({ world: { ...current, player } });
+    if (!current?.life || current.life.gameOver) return;
+    const player = setPendingAttack(current.life.player, id);
+    set({ world: { ...current, life: { ...current.life, player } } });
   },
 
   openInventory: () =>
     set({
       inventoryOpen: true,
       workbenchOpen: false,
+      pastLivesOpen: false,
       selectedNpcId: null,
       selectedRegion: null,
       obstacleContextMenu: null,
@@ -551,12 +571,24 @@ export const useGameStore = create<GameStore>((set, get) => ({
     set({
       workbenchOpen: true,
       inventoryOpen: false,
+      pastLivesOpen: false,
       selectedNpcId: null,
       selectedRegion: null,
       obstacleContextMenu: null,
       npcContextMenu: null,
     }),
   closeWorkbench: () => set({ workbenchOpen: false }),
+  openPastLives: () =>
+    set({
+      pastLivesOpen: true,
+      inventoryOpen: false,
+      workbenchOpen: false,
+      selectedNpcId: null,
+      selectedRegion: null,
+      obstacleContextMenu: null,
+      npcContextMenu: null,
+    }),
+  closePastLives: () => set({ pastLivesOpen: false }),
   openTutorial: () => set({ tutorialOpen: true }),
   closeTutorial: () => set({ tutorialOpen: false }),
   toggleDebug: () => set({ debugMode: !get().debugMode }),
@@ -586,29 +618,31 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   eatFood: (kind: ResourceKind) => {
     const current = get().world;
-    if (!current?.player || current.gameOver) return;
+    if (!current?.life || current.life.gameOver) return;
     if (!RESOURCES[kind].food) return;
-    const have = current.inventory[kind] ?? 0;
+    const life = current.life;
+    const have = life.inventory[kind] ?? 0;
     if (have <= 0) return;
-    const inventory = { ...current.inventory, [kind]: have - 1 };
+    const inventory = { ...life.inventory, [kind]: have - 1 };
     const player: Player = {
-      ...current.player,
-      energy: Math.min(current.player.energyMax, current.player.energy + EAT_ENERGY_PER_FOOD),
-      health: Math.min(current.player.healthMax, current.player.health + EAT_HEALTH_PER_FOOD),
+      ...life.player,
+      energy: Math.min(life.player.energyMax, life.player.energy + EAT_ENERGY_PER_FOOD),
+      health: Math.min(life.player.healthMax, life.player.health + EAT_HEALTH_PER_FOOD),
     };
-    set({ world: { ...current, inventory, player } });
+    set({ world: { ...current, life: { ...life, player, inventory } } });
   },
 
   teleportToRegion: (rx, ry) => {
     const current = get().world;
-    if (!current?.player || current.gameOver) return;
+    if (!current?.life || current.life.gameOver) return;
     const center = regionCenterGlobal(rx, ry);
     const seeded = ensureInteriorsForRegion(current, rx, ry);
     const interior = seeded.biomeInteriors[regionKey(rx, ry)];
     if (!interior) return;
     const target = nearestPassable(interior, center.gx, center.gy, rx, ry);
+    const life = seeded.life!;
     const player: Player = {
-      ...seeded.player!,
+      ...life.player,
       gx: target.gx,
       gy: target.gy,
       route: null,
@@ -616,7 +650,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
       pendingAction: null,
     };
     set({
-      world: { ...seeded, player },
+      world: { ...seeded, life: { ...life, player } },
       view: "biome",
       selectedNpcId: null,
       selectedRegion: null,


### PR DESCRIPTION
Closes #14.

## Summary

- Splits per-life state (player, inventory, gameOver, pickup/projectile buffers, kills, regions discovered, bornAtTick) off `World` into a nullable `LifeState`. Persistent fields (npcs, factions, biome interiors, region control, faction reputation, faction relations) stay flat on `World`.
- Adds an append-only `legacies: Legacy[]` log on `World`. Each entry records name, faction-of-origin, bornAtTick, endedAtTick, ticksAlive, regionsDiscovered, kills, and cause of death.
- New `beginNewLife()`: halves player reputation, picks a random name from `content/traits.ts:NAMES` (avoiding live NPC names) and a random faction-of-origin from `content/factions.ts:FACTIONS`, and chooses a deterministic spawn — original home if its controller isn't hostile, else a wandering NPC of the new faction-of-origin's region, else the BFS-nearest non-hostile passable region.
- `tickWorld` appends a `Legacy` exactly once when `gameOver` flips, increments `kills` on `combat.deaths` whose `killerKind === "player"`, and tracks `discoveredThisLife` separately from world-scoped `discoveredRegions`.
- Bumps `WORLD_VERSION` to 10. The existing version check in `loadFromDisk` discards saves at v9.
- HUD: death overlay now surfaces the just-completed life's name + faction (with `ShapeBadge`), ticks alive, kills, and regions discovered, plus a "View past lives" link. New skull-icon pill button (visible after the first death) opens the panel.
- New `components/PastLivesPanel.tsx`: scrollable list mirroring the slide-up panel chrome from `NpcPanel`. Tap a row to expand inline (born/ended/lived/regions/kills/cause).

## Out of scope (deferred per plan)

- Memorial markers in `WorldScene` for past death tiles.
- A separate Dexie table for legacies — they ride on the existing `default` save row.
- Player picker UI for name/faction at start. Random from existing pools.

## Test plan

Static checks (CI):
- [x] `npm run typecheck` passes.
- [x] `npm run lint` passes.
- [x] `npm run build` passes.

Manual smoke (dev server, Vercel preview, or local `npm run dev`):
- [x] **Fresh start.** Visit `/play?new=1`. Tutorial appears, then the world map. Claim a passable region as home — view switches to biome.
- [x] **First life identity.** `useGameStore.getState().world.life.player` has a `name` and `factionOfOriginId`. Both are non-empty strings drawn from `NAMES` and `FACTIONS`.
- [x] **Pre-death state.** Walk to a tree, chop it, walk to another region, kill an NPC. Note the chopped-tree tile, your inventory, and the death-loot tile after the kill.
- [x] **Trigger death by combat.** Tap a hostile NPC, attack repeatedly until you die.
- [ ] **Death overlay shows life stats.** Headline matches the killer/cause. Stats card shows the life's name, faction (with shape badge), ticks alive (>0), kills (≥1 if you killed before dying), and regions discovered.
- [ ] **View past lives.** Tap "View past lives" — panel opens with one entry. Row shows name, faction, ticks/kills, cause. Tap to expand: born tick, ended tick, ticks alive, regions, kills, cause all populated.
- [ ] **Begin a new life.** Tap "Begin a new life". Spawn lands at home (or nearest non-hostile region if home is now hostile-controlled). New life has a *different* name and (likely) faction. Inventory empty, no weapons/tools.
- [ ] **Persistent obstacles.** Walk back to the previously-chopped tree tile — still gone. Walk to the previous death tile — the `fromDeath` loot pile is still there and pickup-able.
- [ ] **Persistent region control.** Open the world map with faction-zones on. The same faction colors persist on the same tiles as before death.
- [ ] **Reputation halved.** In DevTools: `useGameStore.getState().world.playerReputation`. Each entry should be roughly half of its pre-death value (entries that rounded to 0 are dropped).
- [ ] **Trigger death by starvation.** Walk until energy hits 0, wait until health drains. Overlay shows `cause: "starved"`. Past Lives panel now has two entries.
- [ ] **HUD pill.** After at least one death, a skull-icon button appears in the top pill. Tapping it opens Past Lives.
- [ ] **Save round-trip.** Refresh the browser. Past Lives panel still has both entries. The current life's player coords/inventory persist across refresh.
- [ ] **v9 save discard.** If you have an old v9 save in IndexedDB (DevTools → Application → IndexedDB → `emergentrpg`), refresh: it's discarded and a fresh world starts (homePending).
- [ ] **Hostile-home edge case.** Manually edit a save in DevTools so `regionControl[home]` is set to a faction with `playerReputation` < 0; trigger death; "Begin a new life" — spawn lands somewhere other than home (verify via `world.life.player.gx/gy` against `world.home`).

https://claude.ai/code/session_01SiERAo9HY3JZkyqoeQi2r8