### PR TITLE
Add PlacedStructure schema and bump WORLD_VERSION (#35)

### DIFF
--- a/content/recipes.ts
+++ b/content/recipes.ts
@@ -4,7 +4,20 @@ import type { ToolKind } from "@/lib/sim/tools";
 
 export type RecipeStation = "hand" | "workbench";
 
-export type StructureKind = "workbench";
+export type StructureKind =
+  | "workbench"
+  | "furnace"
+  | "anvil"
+  | "wall_wood"
+  | "wall_stone"
+  | "wall_iron"
+  | "door"
+  | "chest"
+  | "bed"
+  | "campfire"
+  | "floor_tile"
+  | "sign"
+  | "fence";
 
 export type RecipeResult =
   | { kind: "weapon"; id: WeaponKind }

--- a/lib/sim/biome-interior.ts
+++ b/lib/sim/biome-interior.ts
@@ -5,6 +5,7 @@ import {
   RESOURCE_DENSITY,
   type ResourceKind,
 } from "@/content/resources";
+import type { StructureKind } from "@/content/recipes";
 
 export const INTERIOR_W = 20;
 export const INTERIOR_H = 20;
@@ -39,6 +40,23 @@ export type LootPile = {
   fromDeath?: boolean;
 };
 
+export type StructureContents = {
+  items?: Partial<Record<ResourceKind, number>>;
+  weapons?: import("@/lib/sim/weapons").WeaponInstance[];
+  tools?: import("@/lib/sim/tools").ToolInstance[];
+};
+
+export type PlacedStructure = {
+  id: string;
+  kind: StructureKind;
+  lx: number;
+  ly: number;
+  hp?: number;
+  tier?: number;
+  contents?: StructureContents;
+  label?: string;
+};
+
 export type BiomeInterior = {
   rx: number;
   ry: number;
@@ -49,6 +67,7 @@ export type BiomeInterior = {
   // Per-cell tier for cells where obstacles[idx] === "ore_deposit". The map
   // is sparse and only kept in stone biomes; cleared alongside the obstacle.
   oreDeposits: Record<number, OreTier>;
+  placedStructures: PlacedStructure[];
 };
 
 export function regionKey(rx: number, ry: number): string {
@@ -111,6 +130,7 @@ export function generateInterior(worldSeed: number, rx: number, ry: number): Bio
       resources: [],
       loot: [],
       oreDeposits: {},
+      placedStructures: [],
     };
   }
 
@@ -118,7 +138,16 @@ export function generateInterior(worldSeed: number, rx: number, ry: number): Bio
   const oreDeposits: Record<number, OreTier> = {};
   if (biome === "stone") scatterOreDeposits(rng, obstacles, oreDeposits);
   const resources = scatterResources(rng, biome, obstacles);
-  return { rx, ry, biome, obstacles, resources, loot: [], oreDeposits };
+  return {
+    rx,
+    ry,
+    biome,
+    obstacles,
+    resources,
+    loot: [],
+    oreDeposits,
+    placedStructures: [],
+  };
 }
 
 export function isLocalObstacle(interior: BiomeInterior, lx: number, ly: number): boolean {

--- a/lib/sim/world.ts
+++ b/lib/sim/world.ts
@@ -35,7 +35,7 @@ import {
 
 export { biomeAt, isPassable, type Biome } from "@/lib/sim/biome";
 
-export const WORLD_VERSION = 16;
+export const WORLD_VERSION = 17;
 export const MAP_W = 32;
 export const MAP_H = 32;
 export const NPC_COUNT = 200;

--- a/lib/state/game-store.ts
+++ b/lib/state/game-store.ts
@@ -528,10 +528,13 @@ export const useGameStore = create<GameStore>((set, get) => ({
       const wb = findWorkbenchTile(interior);
       if (!wb || chebyshev(here.lx, here.ly, wb.lx, wb.ly) > 1) return false;
     }
-    // Structures must place into the world before we spend inputs.
+    // Structures must place into the world before we spend inputs. Only
+    // the workbench currently lives in the obstacle grid; other structure
+    // kinds in StructureKind land via the build-mode placement UI in B2.
     let placedInteriors: Record<string, import("@/lib/sim/biome-interior").BiomeInterior> | null = null;
     if (recipe.result.kind === "structure") {
       if (!interior) return false;
+      if (recipe.result.id !== "workbench") return false;
       const slot = findAdjacentPassable(interior, here.lx, here.ly, 2);
       if (!slot) return false;
       const nextInterior = placeObstacle(interior, slot.lx, slot.ly, recipe.result.id);


### PR DESCRIPTION
Closes #35
Part of #26

Adds the foundation schema for tile-level structure placement: a `PlacedStructure` type with `id`, `kind`, `lx`, `ly`, optional `hp` / `tier` / `contents` / `label`, and a `placedStructures: PlacedStructure[]` array on `BiomeInterior` (initialized empty in `generateInterior`). `StructureKind` in `content/recipes.ts` expands from `"workbench"` to the full Phase 4b roster (workbench, furnace, anvil, three wall tiers, door, chest, bed, campfire, floor_tile, sign, fence). `WORLD_VERSION` bumps 16 -> 17 so existing saves are discarded via the version check in the store loader. `craftRecipe` narrows to the workbench branch for now since no other structure kinds have placement logic yet (that ships with B2).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YN35t2gkqcgvQLpaHrwTfK)_